### PR TITLE
Overflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
     "scripts/make-checkpoint-header"
 ]
 
+[profile.release]
+overflow-checks = true
+

--- a/chain/chain/src/state_machine.rs
+++ b/chain/chain/src/state_machine.rs
@@ -176,7 +176,7 @@ fn signatories_from_validators(validators: &BTreeMap<Vec<u8>, u64>) -> Result<Si
     let mut signatories = SignatorySet::new();
     for (key_bytes, voting_power) in validators.iter() {
         let key = bitcoin::PublicKey::from_slice(key_bytes.as_slice())?;
-        signatories.set(Signatory::new(key, *voting_power as u32));
+        signatories.set(Signatory::new(key, *voting_power));
     }
     Ok(signatories)
 }

--- a/core/signatory-set/src/reserve_script.rs
+++ b/core/signatory-set/src/reserve_script.rs
@@ -46,7 +46,7 @@ pub fn redeem_script(signatories: &SignatorySet, data: Vec<u8>) -> Script {
         bytes
     });
 
-    let two_thirds = signatories.total_voting_power() as u64 * 2 / 3;
+    let two_thirds = signatories.two_thirds_voting_power();
     bytes.extend(&greater_than_script(two_thirds as u32).into_bytes());
 
     bytes.extend(&data_script(data).into_bytes());

--- a/core/signatory-set/src/reserve_script.rs
+++ b/core/signatory-set/src/reserve_script.rs
@@ -14,9 +14,7 @@ pub fn redeem_script(signatories: &SignatorySet, data: Vec<u8>) -> Script {
     let truncated_voting_power = signatory.voting_power >> truncation;
     let script = script! {
         <signatory.pubkey> OP_CHECKSIG
-        OP_IF <truncated_voting_power as i64>
-        OP_ELSE 0
-        OP_ENDIF
+        <truncated_voting_power as i64> OP_MUL
     };
     let mut bytes = script.into_bytes();
 
@@ -26,9 +24,8 @@ pub fn redeem_script(signatories: &SignatorySet, data: Vec<u8>) -> Script {
         let script = script! {
             OP_SWAP
             <signatory.pubkey> OP_CHECKSIG
-            OP_IF
-                <truncated_voting_power as i64> OP_ADD
-            OP_ENDIF
+            <truncated_voting_power as i64> OP_MUL
+            OP_ADD
         };
         bytes.extend(&script.into_bytes());
     }
@@ -38,13 +35,11 @@ pub fn redeem_script(signatories: &SignatorySet, data: Vec<u8>) -> Script {
         signatories.two_thirds_voting_power() >> truncation;
     let script = script! {
         <truncated_two_thirds as i64> OP_GREATERTHAN
-        OP_VERIFY
     };
     bytes.extend(&script.into_bytes());
 
     // depositor data commitment
-    // (has a 1 at the end so nobody can make an unspendable output)
-    let script = script!(<data> 1);
+    let script = script!(<data> OP_SWAP);
     bytes.extend(&script.into_bytes());
 
     bytes.into()
@@ -58,8 +53,6 @@ fn get_truncation(
     signatories: &SignatorySet,
     target_precision: u32
 ) -> u32 {
-    // TODO: reduce precision more if there is no relative difference (to save
-    // space in script)
     let vp = signatories.total_voting_power();
     let vp_bits = 128 - vp.leading_zeros();
     vp_bits.saturating_sub(target_precision)
@@ -90,39 +83,33 @@ mod tests {
             script,
             bitcoin_script! {
                 0x03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b OP_CHECKSIG
-                OP_IF 3750000
-                OP_ELSE 0
-                OP_ENDIF
+                3750000 OP_MUL
 
                 OP_SWAP
                 0x02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337 OP_CHECKSIG
-                OP_IF
-                    1250000 OP_ADD
-                OP_ENDIF
+                1250000 OP_MUL
+                OP_ADD
 
                 OP_SWAP
                 0x024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766 OP_CHECKSIG
-                OP_IF
-                    937500 OP_ADD
-                OP_ENDIF
+                937500 OP_MUL
+                OP_ADD
 
                 OP_SWAP
                 0x031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f OP_CHECKSIG
-                OP_IF
-                    312500 OP_ADD
-                OP_ENDIF
+                312500 OP_MUL
+                OP_ADD
 
                 4166666 OP_GREATERTHAN
-                OP_VERIFY
 
-                0x010203 1
+                0x010203 OP_SWAP
             }
         );
 
         assert_eq!(
             script.into_bytes(),
             vec![
-                33, 3, 70, 39, 121, 173, 74, 173, 57, 81, 70, 20, 117, 26, 113, 8, 95, 47, 16, 225, 199, 165, 147, 228, 224, 48, 239, 181, 184, 114, 28, 229, 91, 11, 172, 99, 3, 112, 56, 57, 103, 0, 104, 124, 33, 2, 83, 31, 230, 6, 129, 52, 80, 61, 39, 35, 19, 50, 39, 200, 103, 172, 143, 166, 200, 60, 83, 126, 154, 68, 195, 197, 189, 189, 203, 31, 227, 55, 172, 99, 3, 208, 18, 19, 147, 104, 124, 33, 2, 77, 75, 108, 209, 54, 16, 50, 202, 155, 210, 174, 185, 217, 0, 170, 77, 69, 217, 234, 216, 10, 201, 66, 51, 116, 196, 81, 167, 37, 77, 7, 102, 172, 99, 3, 28, 78, 14, 147, 104, 124, 33, 3, 27, 132, 197, 86, 123, 18, 100, 64, 153, 93, 62, 213, 170, 186, 5, 101, 215, 30, 24, 52, 96, 72, 25, 255, 156, 23, 245, 233, 213, 221, 7, 143, 172, 99, 3, 180, 196, 4, 147, 104, 3, 10, 148, 63, 160, 105, 3, 1, 2, 3, 81
+                33, 3, 70, 39, 121, 173, 74, 173, 57, 81, 70, 20, 117, 26, 113, 8, 95, 47, 16, 225, 199, 165, 147, 228, 224, 48, 239, 181, 184, 114, 28, 229, 91, 11, 172, 3, 112, 56, 57, 149, 124, 33, 2, 83, 31, 230, 6, 129, 52, 80, 61, 39, 35, 19, 50, 39, 200, 103, 172, 143, 166, 200, 60, 83, 126, 154, 68, 195, 197, 189, 189, 203, 31, 227, 55, 172, 3, 208, 18, 19, 149, 147, 124, 33, 2, 77, 75, 108, 209, 54, 16, 50, 202, 155, 210, 174, 185, 217, 0, 170, 77, 69, 217, 234, 216, 10, 201, 66, 51, 116, 196, 81, 167, 37, 77, 7, 102, 172, 3, 28, 78, 14, 149, 147, 124, 33, 3, 27, 132, 197, 86, 123, 18, 100, 64, 153, 93, 62, 213, 170, 186, 5, 101, 215, 30, 24, 52, 96, 72, 25, 255, 156, 23, 245, 233, 213, 221, 7, 143, 172, 3, 180, 196, 4, 149, 147, 3, 10, 148, 63, 160, 3, 1, 2, 3, 124
             ]
         );
     }
@@ -134,14 +121,13 @@ mod tests {
         assert_eq!(
             script,
             bitcoin_script! {
-                0 0x7d7aa8c8120655f0419912c34dbd3d8c0d1eff5e266eaacee267a3c3b5cf4f0b
+                0 0x387245be4196638702efb06eabe156e4c0e44629c446e65dd3058a4f327b0e0d
             }
         );
         assert_eq!(
             script.into_bytes(),
             vec![
-                0, 32, 125, 122, 168, 200, 18, 6, 85, 240, 65, 153, 18, 195, 77, 189, 61, 140, 13,
-                30, 255, 94, 38, 110, 170, 206, 226, 103, 163, 195, 181, 207, 79, 11
+                0, 32, 56, 114, 69, 190, 65, 150, 99, 135, 2, 239, 176, 110, 171, 225, 86, 228, 192, 228, 70, 41, 196, 70, 230, 93, 211, 5, 138, 79, 50, 123, 14, 13
             ]
         );
     }

--- a/core/signatory-set/src/signatory_set.rs
+++ b/core/signatory-set/src/signatory_set.rs
@@ -40,11 +40,9 @@ impl SignatorySet {
     }
 
     pub fn two_thirds_voting_power(&self) -> u128 {
-        let vp2 = self.total_voting_power * 2;
-        // check mod 3 so we can ceil the division rather than flooring (it is
-        // safer for this to round up instead of down)
-        let rounding = if vp2 % 3 != 0 { 1 } else { 0 };
-        vp2 / 3 + rounding
+        // it is safe that we round down since the script does a
+        // greater than comparison
+        self.total_voting_power * 2 / 3
     }
  
     pub fn remove(&mut self, pubkey: &PublicKey) -> Option<Signatory> {
@@ -151,6 +149,16 @@ mod tests {
         assert_eq!(set.total_voting_power(), 200);
         set.remove(&mock_pubkey(1));
         assert_eq!(set.total_voting_power(), 100);
+    }
+
+    #[test]
+    fn two_thirds_voting_power() {
+        let mut set = SignatorySet::new();
+        set.add(mock_signatory(1, 100));
+        set.add(mock_signatory(2, 100));
+        assert_eq!(set.two_thirds_voting_power(), 133);
+        set.remove(&mock_pubkey(1));
+        assert_eq!(set.two_thirds_voting_power(), 66);
     }
 
     #[test]

--- a/core/signatory-set/src/test_utils.rs
+++ b/core/signatory-set/src/test_utils.rs
@@ -13,14 +13,14 @@ pub fn mock_pubkey(byte: u8) -> PublicKey {
     privkey.public_key(&secp)
 }
 
-pub fn mock_signatory(key_byte: u8, voting_power: u32) -> Signatory {
+pub fn mock_signatory(key_byte: u8, voting_power: u64) -> Signatory {
     Signatory::new(mock_pubkey(key_byte), voting_power)
 }
 
 pub fn mock_signatory_set(count: usize) -> SignatorySet {
     let mut signatories = SignatorySet::new();
     for i in 1..=count {
-        signatories.set(mock_signatory(i as u8, i as u32));
+        signatories.set(mock_signatory(i as u8, i as u64));
     }
     signatories
 }


### PR DESCRIPTION
This PR fixes issues with signatory set voting power overflows. It works by truncating in a way where the sum of the signatory set voting power is guaranteed to be at most 23 bits (chosen because it's a good enough level of precision, and will only take up 3 bytes when encoded as a Bitcoin varint - it's 23 and not 24 because Bitcoin uses the MSB as a sign bit).

Some signatories may end up with 0 effective voting power but for now we just keep them in the script - in the future we can remove them to save space.