### PR TITLE
doc: add instruction to specify external_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,22 @@ Initialize your data directory (`~/.nomic-stakenet-rc`) by running:
 nomic init
 ```
 
-Next, add a seed so your node will be able to connect to the network by editing
-`~/.nomic-stakenet-rc/tendermint/config/config.toml`:
+Next, configure your node by editing
+`~/.nomic-stakenet-rc/tendermint/config/config.toml`.
+
+Add the external ip and port where your node can be reached so that other
+nodes will connect to you:
+
+```toml
+# Address to advertise to peers for them to dial
+# If empty, will use the same port as the laddr,
+# and will introspect on the listener or use UPnP
+# to figure out the address. ip and port are required
+# example: 159.89.10.97:26656
+external_address = "123.45.67.89:26656"
+```
+
+Add a seed so your node will be able to connect to the network:
 
 ```toml
 # Comma separated list of seed nodes to connect to


### PR DESCRIPTION
When no `external_address` or `laddr` is specified in `config.toml`, the node will not be discoverable if introspection fails, as the default laddr IP is set to 0.0.0.0:26656 - this guides a node operator to set it.

For me, on Debian 11 without UPnP, introspection to determine my external IP either doesn't work, or doesn't persist - this probably needs to be fixed (in informalsystems/tendermint-rs?) 

Until then, this workaround seems to do it. 