### PR TITLE
Validator UX / node management improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "pretty_env_logger",
  "rand 0.8.5",
  "reqwest",
+ "semver 1.0.18",
  "serde",
  "serde-big-array",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.29.2", features = ["serde", "rand"] }
 bitcoind = { version = "0.27.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "c5e44ab1b1c008212c175c6c6c47aecaa5948307", features = ["merk-verify"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "028725159d614e28e5cc8f642a7d7e19e7a97afe", features = ["merk-verify"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ default = ["full", "feat-ibc", "testnet"]
 full = ["bitcoind", "bitcoincore-rpc-async", "clap", "tokio", "orga/merk-full", "orga/abci", "orga/state-sync", "csv", "warp", "rand", "reqwest", "tendermint-rpc", "home"]
 feat-ibc = ["orga/feat-ibc"]
 testnet = []
-devnet = ["testnet"]
 emergency-disbursal = []
 legacy-bin = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 semver = "1.0.18"
 
 [features]
-default = ["full", "feat-ibc", "testnet"]
+default = ["full", "feat-ibc", "testnet", "legacy-bin"]
 full = ["bitcoind", "bitcoincore-rpc-async", "clap", "tokio", "orga/merk-full", "orga/abci", "orga/state-sync", "csv", "warp", "rand", "reqwest", "tendermint-rpc", "home"]
 feat-ibc = ["orga/feat-ibc"]
 testnet = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ chrono = "0.4.19"
 serial_test = "2.0.0"
 tempfile = "3.6.0"
 
+[build-dependencies]
+toml = { version = "0.7.2", features = ["parse"] }
+
 [features]
 default = ["full", "feat-ibc", "testnet"]
 full = ["bitcoind", "bitcoincore-rpc-async", "clap", "tokio", "orga/merk-full", "orga/abci", "orga/state-sync", "csv", "warp", "rand", "reqwest", "tendermint-rpc", "home"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ split-iter = "0.1.0"
 chrono = "0.4.19"
 tempfile = "3"
 home = {version = "0.5.5", optional = true }
+semver = "1.0.18"
 
 [dev-dependencies]
 bitcoin_hashes = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tempfile = "3.6.0"
 
 [build-dependencies]
 toml = { version = "0.7.2", features = ["parse"] }
+semver = "1.0.18"
 
 [features]
 default = ["full", "feat-ibc", "testnet"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ feat-ibc = ["orga/feat-ibc"]
 testnet = []
 devnet = ["testnet"]
 emergency-disbursal = []
+legacy-bin = []
 
 [profile.release]
 overflow-checks = true

--- a/build.rs
+++ b/build.rs
@@ -7,4 +7,25 @@ fn main() {
         "cargo:rustc-env=GIT_BRANCH={}",
         String::from_utf8(branch_name.stdout).unwrap().trim(),
     );
+
+    #[cfg(feature = "legacy-bin")]
+    {
+        println!("cargo:rerun-if-changed=build.sh");
+
+        let shell = std::env::var("SHELL").unwrap_or("/bin/bash".to_string());
+        println!("using shell: {}", shell);
+
+        // TODO: decide how to configure rev (support multiple?)
+        let legacy_rev = "testnet".to_string();
+
+        std::process::Command::new(shell)
+            .env_clear()
+            .env("OUT_DIR", std::env::var("OUT_DIR").unwrap())
+            .env("NOMIC_LEGACY_REV", legacy_rev)
+            .args(["build.sh"])
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -44,14 +44,15 @@ fn main() {
             .max()
             .unwrap();
 
-        std::process::Command::new(shell)
+        let res = std::process::Command::new(shell)
             .env_clear()
             .env("OUT_DIR", std::env::var("OUT_DIR").unwrap())
             .env("NOMIC_LEGACY_REV", format!("v{}", version))
             .args(["build.sh"])
             .spawn()
             .unwrap()
-            .wait()
+            .wait_with_output()
             .unwrap();
+        assert!(res.status.success());
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,14 @@ fn main() {
         }
         let version_req = semver::VersionReq::parse(&version_req_str).unwrap();
 
+        assert!(std::process::Command::new("git")
+            .args(["fetch", "--tags"])
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .unwrap()
+            .status
+            .success());
         let version = std::process::Command::new("git")
             .args(["tag"])
             .output()

--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,7 @@ fn main() {
         let res = std::process::Command::new(shell)
             .env_clear()
             .env("OUT_DIR", std::env::var("OUT_DIR").unwrap())
+            .env("PATH", std::env::var("PATH").unwrap())
             .env("NOMIC_LEGACY_REV", rev)
             .args(["build.sh"])
             .spawn()

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let branch_name = std::process::Command::new("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .output()
+        .unwrap();
+    println!(
+        "cargo:rustc-env=GIT_BRANCH={}",
+        String::from_utf8(branch_name.stdout).unwrap().trim(),
+    );
+}

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ fn main() {
             .stdout
             .split(|&b| b == b'\n')
             .map(|b| String::from_utf8(b.to_vec()).unwrap())
-            .filter(|s| s.starts_with("v"))
+            .filter(|s| s.starts_with('v'))
             .filter_map(|s| semver::Version::parse(&s[1..]).ok())
             .filter(|v| version_req.matches(v))
             .max()

--- a/build.rs
+++ b/build.rs
@@ -3,25 +3,36 @@ fn main() {
         .args(["symbolic-ref", "--short", "HEAD"])
         .output()
         .unwrap();
-    println!(
-        "cargo:rustc-env=GIT_BRANCH={}",
-        String::from_utf8(branch_name.stdout).unwrap().trim(),
-    );
+    let branch_name = String::from_utf8(branch_name.stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    println!("cargo:rustc-env=GIT_BRANCH={}", branch_name);
 
     #[cfg(feature = "legacy-bin")]
     {
         println!("cargo:rerun-if-changed=build.sh");
-
         let shell = std::env::var("SHELL").unwrap_or("/bin/bash".to_string());
         println!("using shell: {}", shell);
-
-        // TODO: decide how to configure rev (support multiple?)
-        let legacy_rev = "testnet".to_string();
+        let version = if branch_name == "main" {
+            todo!()
+        } else {
+            let toml = include_str!("networks/testnet.toml");
+            let config: toml::Value = toml::from_str(toml).unwrap();
+            config
+                .as_table()
+                .unwrap()
+                .get("legacy_version")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
 
         std::process::Command::new(shell)
             .env_clear()
             .env("OUT_DIR", std::env::var("OUT_DIR").unwrap())
-            .env("NOMIC_LEGACY_REV", legacy_rev)
+            .env("NOMIC_LEGACY_REV", format!("v{}", version))
             .args(["build.sh"])
             .spawn()
             .unwrap()

--- a/build.sh
+++ b/build.sh
@@ -3,18 +3,27 @@
 set -e
 
 BUILD_DIR=$OUT_DIR/nomic
-echo "Building legacy nomic at $BUILD_DIR..."
-if [ ! -d "$BUILD_DIR" ]; then
-    git clone https://github.com/nomic-io/nomic.git $OUT_DIR/nomic
-fi
-cd $BUILD_DIR
-git checkout .
-git checkout main
-git pull
-git checkout $NOMIC_LEGACY_REV
+NOMIC_LEGACY_PATH=$OUT_DIR/nomic-bin
 
-rustc --version
-cargo build --release
-NOMIC_LEGACY_PATH=$OUT_DIR/nomic/target/release/nomic
+if [ ! -f "$NOMIC_LEGACY_PATH" ]; then
+    echo "Building legacy nomic at $BUILD_DIR..."
+    if [ ! -d "$BUILD_DIR" ]; then
+        git clone https://github.com/nomic-io/nomic.git $BUILD_DIR
+    fi
+    cd $BUILD_DIR
+    git checkout .
+    git checkout main
+    git pull
+    git checkout $NOMIC_LEGACY_REV
+
+    rustc --version
+    cargo build --release
+    mv $BUILD_DIR/target/release/nomic $NOMIC_LEGACY_PATH
+else
+    echo "Skipping legacy nomic binary build (already exists at $NOMIC_LEGACY_PATH)" 
+fi
+
+rm -rf $BUILD_DIR
+
 echo "cargo:rustc-env=NOMIC_LEGACY_BUILD_PATH=$NOMIC_LEGACY_PATH"
 echo "cargo:rustc-env=NOMIC_LEGACY_BUILD_VERSION=$($NOMIC_LEGACY_PATH --version)"

--- a/build.sh
+++ b/build.sh
@@ -16,5 +16,5 @@ git checkout $NOMIC_LEGACY_REV
 rustc --version
 cargo build --release
 NOMIC_LEGACY_PATH=$OUT_DIR/nomic/target/release/nomic
-echo "cargo:rustc-env=NOMIC_LEGACY_PATH=$NOMIC_LEGACY_PATH"
-echo "cargo:rustc-env=NOMIC_LEGACY_VERSION=$($NOMIC_LEGACY_PATH --version)"
+echo "cargo:rustc-env=NOMIC_LEGACY_BUILD_PATH=$NOMIC_LEGACY_PATH"
+echo "cargo:rustc-env=NOMIC_LEGACY_BUILD_VERSION=$($NOMIC_LEGACY_PATH --version)"

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-echo "Building legacy nomic at $OUT_DIR/nomic..."
-git clone https://github.com/nomic-io/nomic.git $OUT_DIR/nomic
-cd $OUT_DIR/nomic
-git reset --hard main
+BUILD_DIR=$OUT_DIR/nomic
+echo "Building legacy nomic at $BUILD_DIR..."
+if [ ! -d "$BUILD_DIR" ]; then
+    git clone https://github.com/nomic-io/nomic.git $OUT_DIR/nomic
+fi
+cd $BUILD_DIR
+git checkout .
+git checkout main
 git pull
 git checkout $NOMIC_LEGACY_REV
 

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 BUILD_DIR=$OUT_DIR/nomic
-NOMIC_LEGACY_PATH=$OUT_DIR/nomic-bin
+NOMIC_LEGACY_PATH=$OUT_DIR/nomic-$NOMIC_LEGACY_REV
 
 if [ ! -f "$NOMIC_LEGACY_PATH" ]; then
     echo "Building legacy nomic at $BUILD_DIR..."

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 BUILD_DIR=$OUT_DIR/nomic
 echo "Building legacy nomic at $BUILD_DIR..."
 if [ ! -d "$BUILD_DIR" ]; then

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@
 echo "Building legacy nomic at $OUT_DIR/nomic..."
 git clone https://github.com/nomic-io/nomic.git $OUT_DIR/nomic
 cd $OUT_DIR/nomic
-git checkout .
-git checkout $NOMIC_LEGACY_REV
+git reset --hard main
 git pull
+git checkout $NOMIC_LEGACY_REV
 
 rustc --version
 cargo build --release

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Building legacy nomic at $OUT_DIR/nomic..."
+git clone https://github.com/nomic-io/nomic.git $OUT_DIR/nomic
+cd $OUT_DIR/nomic
+git checkout .
+git checkout $NOMIC_LEGACY_REV
+git pull
+
+rustc --version
+cargo build --release
+NOMIC_LEGACY_PATH=$OUT_DIR/nomic/target/release/nomic
+echo "cargo:rustc-env=NOMIC_LEGACY_PATH=$NOMIC_LEGACY_PATH"
+echo "cargo:rustc-env=NOMIC_LEGACY_VERSION=$($NOMIC_LEGACY_PATH --version)"

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -1,4 +1,3 @@
-chain_id = "nomic-testnet-4d"
 state_sync_rpc = [
     "http://147.182.171.216:26667",
     "http://147.182.171.216:26677",

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -2,6 +2,7 @@ chain_id = "nomic-testnet-4d"
 state_sync_rpc = [
     "http://147.182.171.216:26667",
     "http://147.182.171.216:26677",
+    "https://rpc.nomic-testnet.basementnodes.ca"
 ]
 tendermint_flags = [
     "--p2p.seeds",

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -11,7 +11,7 @@ tendermint_flags = [
     """,
 ]
 
-legacy_version = "5.0.0"
+legacy_version = "=5.1"
 
 genesis = """
 {

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -10,7 +10,7 @@ tendermint_flags = [
     """,
 ]
 
-legacy_version = "=5.1"
+legacy_version = "5.1"
 
 genesis = """
 {

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "pretty_env_logger",
  "rand 0.8.5",
  "reqwest",
+ "semver 1.0.18",
  "serde",
  "serde-big-array",
  "serde_json",

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -2,7 +2,7 @@
 extern crate rocket;
 
 use nomic::{
-    app::{App, InnerApp, Nom, CHAIN_ID},
+    app::{App, InnerApp, Nom},
     app_client_testnet,
     orga::{
         coins::{Address, Amount, Decimal},

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,6 @@ use std::fmt::Debug;
 
 mod migrations;
 
-pub const CHAIN_ID: &str = "nomic-testnet-4d";
 pub type AppV0 = DefaultPlugins<Nom, InnerAppV0>;
 pub type App = DefaultPlugins<Nom, InnerApp>;
 

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1434,10 +1434,14 @@ impl DevnetCmd {
 }
 
 pub fn main() {
-    pretty_env_logger::formatted_timed_builder()
-        .filter_level(log::LevelFilter::Info)
-        .parse_env("NOMIC_LOG")
-        .init();
+    if std::env::var("NOMIC_LOG_SIMPLE").is_ok() {
+        pretty_env_logger::formatted_builder()
+    } else {
+        pretty_env_logger::formatted_timed_builder()
+    }
+    .filter_level(log::LevelFilter::Info)
+    .parse_env("NOMIC_LOG")
+    .init();
 
     let backtrace_enabled = std::env::var("RUST_BACKTRACE").is_ok();
 

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -187,7 +187,7 @@ pub struct StartCmd {
 impl StartCmd {
     fn run(&self) -> orga::Result<()> {
         let cmd = self.clone();
-        let home = &cmd.config.home();
+        let home = cmd.config.home()?;
 
         if cmd.freeze_valset {
             std::env::set_var("ORGA_STATIC_VALSET", "true");
@@ -364,7 +364,7 @@ impl StartCmd {
 
 // TODO: move to config/nodehome?
 fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
-    let home = config.home();
+    let home = config.home()?;
 
     // TODO: skip if specifying node in config
 
@@ -1011,7 +1011,7 @@ impl RelayerCmd {
         let mut relayer = create_relayer().await;
         let headers = relayer.start_header_relay();
 
-        let relayer_dir_path = self.config.home().join("relayer");
+        let relayer_dir_path = self.config.home()?.join("relayer");
         if !relayer_dir_path.exists() {
             std::fs::create_dir(&relayer_dir_path)?;
         }
@@ -1047,7 +1047,7 @@ pub struct SignerCmd {
 
 impl SignerCmd {
     async fn run(&self) -> Result<()> {
-        let signer_dir_path = self.config.home().join("signer");
+        let signer_dir_path = self.config.home()?.join("signer");
         if !signer_dir_path.exists() {
             std::fs::create_dir(&signer_dir_path)?;
         }
@@ -1287,7 +1287,7 @@ pub struct ExportCmd {
 
 impl ExportCmd {
     async fn run(&self) -> Result<()> {
-        let home = self.config.home();
+        let home = self.config.home()?;
 
         let store_path = home.join("merk");
         let store = Store::new(orga::store::BackingStore::Merk(orga::store::Shared::new(

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -352,6 +352,9 @@ impl StartCmd {
             });
         }
 
+        if std::env::var("NOMIC_EXIT_ON_START").is_ok() {
+            std::process::exit(139);
+        }
         node.stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .print_tendermint_logs(cmd.tendermint_logs)

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1448,6 +1448,8 @@ pub fn main() {
     .parse_env("NOMIC_LOG")
     .init();
 
+    log::debug!("nomic v{}", env!("CARGO_PKG_VERSION"));
+
     let backtrace_enabled = std::env::var("RUST_BACKTRACE").is_ok();
 
     let panic_handler = if backtrace_enabled {

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -345,7 +345,8 @@ impl StartCmd {
         }
         if let Some(signal_version) = cmd.signal_version {
             let signal_version = hex::decode(signal_version).unwrap();
-            tokio::spawn(async move {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.spawn(async move {
                 let signal_version = signal_version.clone();
                 let signal_version2 = signal_version.clone();
                 let signal_version3 = signal_version.clone();

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -84,7 +84,6 @@ pub enum Command {
     Signer(SignerCmd),
     SetSignatoryKey(SetSignatoryKeyCmd),
     Deposit(DepositCmd),
-    Devnet(DevnetCmd),
     #[cfg(feature = "testnet")]
     InterchainDeposit(InterchainDepositCmd),
     Withdraw(WithdrawCmd),
@@ -125,7 +124,6 @@ impl Command {
                 Delegate(cmd) => cmd.run().await,
                 Declare(cmd) => cmd.run().await,
                 Delegations(cmd) => cmd.run().await,
-                Devnet(cmd) => cmd.run().await,
                 Validators(cmd) => cmd.run().await,
                 Unbond(cmd) => cmd.run().await,
                 Redelegate(cmd) => cmd.run().await,
@@ -1382,82 +1380,6 @@ impl ExportCmd {
         serde_json::to_writer_pretty(std::io::stdout(), &app).unwrap();
 
         Ok(())
-    }
-}
-
-#[derive(Parser, Debug)]
-pub struct DevnetCmd {}
-
-impl DevnetCmd {
-    async fn run(&self) -> Result<()> {
-        todo!();
-        // // pretty_env_logger::init();
-        // let genesis_time = Utc.with_ymd_and_hms(2022, 10, 5, 0, 0, 0).unwrap();
-        // let ctx = Time::from_seconds(genesis_time.timestamp());
-        // Context::add(ctx);
-
-        // let home = tempdir().unwrap();
-        // let path = home.into_path();
-
-        // let mut conf = Conf::default();
-        // conf.args.push("-txindex");
-        // let bitcoind =
-        //     BitcoinD::with_conf(bitcoind::downloaded_exe_path().unwrap(), &conf).unwrap();
-
-        // let block_data = populate_bitcoin_block(&bitcoind);
-
-        // let node_path = path.clone();
-        // let signer_path = path.clone();
-        // let drop_path = path.clone();
-        // let header_relayer_path = path.clone();
-
-        // std::env::set_var("NOMIC_HOME_DIR", &path);
-
-        // let _ = setup_test_app(&path, &block_data);
-
-        // std::thread::spawn(move || {
-        //     info!("Starting Nomic node...");
-        //     Node::<nomic::app::App>::new(&node_path, nomic::app::CHAIN_ID, Default::default());
-        // });
-
-        // std::thread::spawn(move || {
-        //     info!("Starting rest server...");
-        //     start_rest().unwrap();
-        // });
-
-        // let relayer_config = RelayerConfig {
-        //     network: bitcoin::Network::Regtest,
-        // };
-
-        // let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind).await, app_client())
-        //     .configure(relayer_config.clone());
-        // let headers = relayer.start_header_relay();
-
-        // let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind).await, app_client())
-        //     .configure(relayer_config.clone());
-        // let deposits = relayer.start_deposit_relay(&header_relayer_path);
-
-        // let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind).await, app_client())
-        //     .configure(relayer_config.clone());
-        // let checkpoints = relayer.start_checkpoint_relay();
-
-        // let signer = async {
-        //     poll_for_blocks().await;
-        //     tokio::time::sleep(Duration::from_secs(20)).await;
-        //     setup_test_signer(&signer_path).start().await
-        // };
-
-        // let declarer = async {
-        //     poll_for_blocks().await;
-        //     declare_validator(&path).await.unwrap();
-
-        //     Err::<(), NomicError>(NomicError::Test("Test completed successfully".to_string()))
-        // };
-
-        // let _ = futures::join!(headers, deposits, checkpoints, signer, declarer);
-        // std::fs::remove_dir_all(drop_path).unwrap();
-
-        // Ok(())
     }
 }
 

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -187,7 +187,7 @@ pub struct StartCmd {
 impl StartCmd {
     fn run(&self) -> orga::Result<()> {
         let cmd = self.clone();
-        let home = cmd.config.home()?;
+        let home = cmd.config.home_expect()?;
 
         if cmd.freeze_valset {
             std::env::set_var("ORGA_STATIC_VALSET", "true");
@@ -365,7 +365,14 @@ impl StartCmd {
 
 // TODO: move to config/nodehome?
 fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
-    let home = config.home()?;
+    let home = match config.home() {
+        Some(home) => home,
+        None => {
+            log::warn!("Unknown home directory, cannot automatically run legacy binary.");
+            log::warn!("If the command fails, try running with an older version.");
+            return Ok(None);
+        }
+    };
 
     // TODO: skip if specifying node in config
 
@@ -472,9 +479,16 @@ fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
 }
 
 async fn relaunch_on_migrate(config: &nomic::network::Config) -> Result<()> {
+    let home = match config.home() {
+        Some(home) => home,
+        None => {
+            log::warn!("Unknown home directory, cannot automatically relaunch on migrate");
+            return Ok(());
+        }
+    };
+
     let mut initial_ver = None;
     loop {
-        let home = config.home().unwrap();
         if !home.exists() {
             continue;
         }
@@ -1064,7 +1078,7 @@ impl RelayerCmd {
         let mut relayer = create_relayer().await;
         let headers = relayer.start_header_relay();
 
-        let relayer_dir_path = self.config.home()?.join("relayer");
+        let relayer_dir_path = self.config.home_expect()?.join("relayer");
         if !relayer_dir_path.exists() {
             std::fs::create_dir(&relayer_dir_path)?;
         }
@@ -1102,7 +1116,7 @@ pub struct SignerCmd {
 
 impl SignerCmd {
     async fn run(&self) -> Result<()> {
-        let signer_dir_path = self.config.home()?.join("signer");
+        let signer_dir_path = self.config.home_expect()?.join("signer");
         if !signer_dir_path.exists() {
             std::fs::create_dir(&signer_dir_path)?;
         }
@@ -1345,7 +1359,7 @@ pub struct ExportCmd {
 
 impl ExportCmd {
     async fn run(&self) -> Result<()> {
-        let home = self.config.home()?;
+        let home = self.config.home_expect()?;
 
         let store_path = home.join("merk");
         let store = Store::new(orga::store::BackingStore::Merk(orga::store::Shared::new(

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -402,9 +402,11 @@ fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
                 let bin_name = env!("NOMIC_LEGACY_VERSION").trim().replace(" ", "-");
                 let bin_path = bin_dir.join(bin_name);
                 let bin_bytes = include_bytes!(env!("NOMIC_LEGACY_PATH"));
-                log::debug!("Writing legacy binary to {}...", bin_path.display());
-                std::fs::write(&bin_path, bin_bytes).unwrap();
-                std::fs::set_permissions(bin_path, Permissions::from_mode(0o777)).unwrap();
+                if !bin_path.exists() {
+                    log::debug!("Writing legacy binary to {}...", bin_path.display());
+                    std::fs::write(&bin_path, bin_bytes).unwrap();
+                    std::fs::set_permissions(bin_path, Permissions::from_mode(0o777)).unwrap();
+                }
             }
 
             if !bin_dir.exists() {

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -369,7 +369,7 @@ fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
         Some(home) => home,
         None => {
             log::warn!("Unknown home directory, cannot automatically run legacy binary.");
-            log::warn!("If the command fails, try running with an older version.");
+            log::warn!("If the command fails, try running with --network, --home, or --chain-id.");
             return Ok(None);
         }
     };
@@ -415,7 +415,7 @@ fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
                     std::fs::create_dir_all(&bin_dir)?;
                 }
 
-                let bin_name = env!("NOMIC_LEGACY_BUILD_VERSION").trim().replace(" ", "-");
+                let bin_name = env!("NOMIC_LEGACY_BUILD_VERSION").trim().replace(' ', "-");
                 let bin_path = bin_dir.join(bin_name);
                 let bin_bytes = include_bytes!(env!("NOMIC_LEGACY_BUILD_PATH"));
                 if !bin_path.exists() {
@@ -503,7 +503,7 @@ async fn relaunch_on_migrate(config: &nomic::network::Config) -> Result<()> {
         }
         let store = MerkStore::open_readonly(home.join("merk"));
         let store_ver = store.merk().get_aux(b"consensus_version").unwrap();
-        if let Some(_) = &initial_ver {
+        if initial_ver.is_some() {
             if store_ver != initial_ver {
                 log::info!(
                     "Node has migrated from version {:?} to version {:?}, exiting",

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -198,15 +198,8 @@ impl StartCmd {
         if let Some(legacy_bin) = legacy_bin {
             let version_hex = hex::encode([InnerApp::CONSENSUS_VERSION]);
             let mut legacy_cmd = std::process::Command::new(legacy_bin);
-            legacy_cmd.args([
-                "start",
-                "--signal-version",
-                &version_hex,
-                "--home",
-                home.to_str().unwrap(),
-                "--",
-            ]);
-            legacy_cmd.args(&cmd.config.tendermint_flags);
+            legacy_cmd.args(["start", "--signal-version", &version_hex]);
+            legacy_cmd.args(std::env::args().skip(2).collect::<Vec<_>>());
             log::info!("Starting legacy node... ({:#?})", legacy_cmd);
             let res = legacy_cmd.spawn()?.wait()?;
             match res.code() {

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -926,12 +926,8 @@ pub struct RelayerCmd {
     #[clap(short = 'P', long)]
     rpc_pass: Option<String>,
 
-    #[clap(long)]
-    path: Option<String>,
-
-    // TODO: use same config/network as StartCmd
-    #[clap(long)]
-    chain_id: Option<String>,
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 impl RelayerCmd {
@@ -958,18 +954,7 @@ impl RelayerCmd {
         let mut relayer = create_relayer().await;
         let headers = relayer.start_header_relay();
 
-        if self.path.is_none() && self.chain_id.is_none() {
-            return Err(orga::Error::App(
-                "Either --path or --chain-id must be specified".to_string(),
-            )
-            .into());
-        }
-
-        let relayer_dir_path = self
-            .path
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| Node::home(self.chain_id.as_ref().unwrap()).join("relayer"));
+        let relayer_dir_path = self.config.home().join("relayer");
         if !relayer_dir_path.exists() {
             std::fs::create_dir(&relayer_dir_path)?;
         }
@@ -988,13 +973,8 @@ impl RelayerCmd {
 
 #[derive(Parser, Debug)]
 pub struct SignerCmd {
-    /// Path to the signatory private key
-    #[clap(short, long)]
-    path: Option<String>,
-
-    // TODO: use same config/network as StartCmd
-    #[clap(long)]
-    chain_id: Option<String>,
+    #[clap(flatten)]
+    config: nomic::network::Config,
 
     /// Limits the fraction of the total reserve that may be withdrawn within
     /// the trailing 24-hour period
@@ -1010,18 +990,7 @@ pub struct SignerCmd {
 
 impl SignerCmd {
     async fn run(&self) -> Result<()> {
-        if self.path.is_none() && self.chain_id.is_none() {
-            return Err(orga::Error::App(
-                "Either --path or --chain-id must be specified".to_string(),
-            )
-            .into());
-        }
-
-        let signer_dir_path = self
-            .path
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| Node::home(self.chain_id.as_ref().unwrap()).join("signer"));
+        let signer_dir_path = self.config.home().join("signer");
         if !signer_dir_path.exists() {
             std::fs::create_dir(&signer_dir_path)?;
         }
@@ -1255,13 +1224,13 @@ impl IbcTransferCmd {
 
 #[derive(Parser, Debug)]
 pub struct ExportCmd {
-    #[clap(long)]
-    home: String,
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 impl ExportCmd {
     async fn run(&self) -> Result<()> {
-        let home = PathBuf::from_str(&self.home).unwrap();
+        let home = self.config.home();
 
         let store_path = home.join("merk");
         let store = Store::new(orga::store::BackingStore::Merk(orga::store::Shared::new(

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -975,6 +975,10 @@ pub struct RelayerCmd {
 
     #[clap(long)]
     path: Option<String>,
+
+    // TODO: use same config/network as StartCmd
+    #[clap(long)]
+    chain_id: Option<String>,
 }
 
 impl RelayerCmd {
@@ -1001,14 +1005,22 @@ impl RelayerCmd {
         let mut relayer = create_relayer().await;
         let headers = relayer.start_header_relay();
 
+        if self.path.is_none() && self.chain_id.is_none() {
+            return Err(orga::Error::App(
+                "Either --path or --chain-id must be specified".to_string(),
+            )
+            .into());
+        }
+
         let relayer_dir_path = self
             .path
             .as_ref()
             .map(PathBuf::from)
-            .unwrap_or_else(|| Node::home(nomic::app::CHAIN_ID).join("relayer"));
+            .unwrap_or_else(|| Node::home(self.chain_id.as_ref().unwrap()).join("relayer"));
         if !relayer_dir_path.exists() {
             std::fs::create_dir(&relayer_dir_path)?;
         }
+
         let relayer = create_relayer().await;
         let deposits = relayer.start_deposit_relay(relayer_dir_path);
 
@@ -1026,6 +1038,11 @@ pub struct SignerCmd {
     /// Path to the signatory private key
     #[clap(short, long)]
     path: Option<String>,
+
+    // TODO: use same config/network as StartCmd
+    #[clap(long)]
+    chain_id: Option<String>,
+
     /// Limits the fraction of the total reserve that may be withdrawn within
     /// the trailing 24-hour period
     #[clap(long, default_value_t = 0.04)]
@@ -1040,14 +1057,22 @@ pub struct SignerCmd {
 
 impl SignerCmd {
     async fn run(&self) -> Result<()> {
+        if self.path.is_none() && self.chain_id.is_none() {
+            return Err(orga::Error::App(
+                "Either --path or --chain-id must be specified".to_string(),
+            )
+            .into());
+        }
+
         let signer_dir_path = self
             .path
             .as_ref()
             .map(PathBuf::from)
-            .unwrap_or_else(|| Node::home(nomic::app::CHAIN_ID).join("signer"));
+            .unwrap_or_else(|| Node::home(self.chain_id.as_ref().unwrap()).join("signer"));
         if !signer_dir_path.exists() {
             std::fs::create_dir(&signer_dir_path)?;
         }
+
         let key_path = signer_dir_path.join("xpriv");
 
         let signer = Signer::load_or_generate(

--- a/src/bitcoin/header_queue.rs
+++ b/src/bitcoin/header_queue.rs
@@ -389,7 +389,7 @@ impl HeaderQueue {
                 .ok_or_else(|| Error::Header("Header not found".into()))?;
 
             if first_replaced.block_hash() == first.block_hash() {
-                return Err(Error::Header("Provided redudant header.".into()));
+                return Err(Error::Header("Provided redundant header.".into()));
             }
 
             removed_work = self.pop_back_to(first.height)?;

--- a/src/network.rs
+++ b/src/network.rs
@@ -73,13 +73,10 @@ pub struct Config(InnerConfig);
 
 impl Config {
     pub fn home(&self) -> Option<PathBuf> {
-        if let Some(home) = self.home.as_ref() {
-            Some(PathBuf::from(home))
-        } else if let Some(chain_id) = self.chain_id.as_ref() {
-            Some(orga::abci::Node::home(chain_id))
-        } else {
-            None
-        }
+        self.home
+            .as_ref()
+            .map(PathBuf::from)
+            .or(self.chain_id.as_ref().map(|c| orga::abci::Node::home(c)))
     }
 
     pub fn home_expect(&self) -> Result<PathBuf> {

--- a/src/network.rs
+++ b/src/network.rs
@@ -177,7 +177,24 @@ impl FromArgMatches for Config {
             self.0 = net_config;
         }
 
-        // TODO: get chain id from genesis
+        if let Some(genesis) = self.0.genesis.as_ref() {
+            let genesis: serde_json::Value = genesis.parse().unwrap();
+            let gensis_cid = genesis["chain_id"].as_str().unwrap();
+
+            if let Some(cid) = self.0.chain_id.as_ref() {
+                if cid != gensis_cid {
+                    return Err(clap::Error::raw(
+                        ErrorKind::ArgumentConflict,
+                        format!(
+                            "Genesis chain ID ({}) does not match --chain-id ({})",
+                            gensis_cid, cid
+                        ),
+                    ));
+                }
+            } else {
+                self.0.chain_id = Some(gensis_cid.to_string());
+            }
+        }
 
         Ok(())
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -122,14 +122,16 @@ impl FromArgMatches for Config {
         self.0.update_from_arg_matches(matches)?;
 
         if self.is_empty() {
-            self.0.network = match std::env::var("GIT_BRANCH").as_deref() {
-                Ok("main") => Some(Network::Mainnet),
-                Ok("testnet") => Some(Network::Testnet),
-                _ => {
-                    log::warn!("Built on branch with no default network. Use --network to specify a network.");
-                    None
-                }
+            self.0.network = match env!("GIT_BRANCH") {
+                "main" => Some(Network::Mainnet),
+                "testnet" => Some(Network::Testnet),
+                _ => None,
             };
+            if let Some(network) = self.0.network {
+                log::debug!("Using default network: {:?}", network);
+            } else {
+                log::debug!("Built on branch with no default network.");
+            }
         }
 
         if let Some(network) = self.0.network {

--- a/src/network.rs
+++ b/src/network.rs
@@ -126,7 +126,7 @@ impl FromArgMatches for Config {
                 Ok("main") => Some(Network::Mainnet),
                 Ok("testnet") => Some(Network::Testnet),
                 _ => {
-                    log::warn!("Building on branch with no default network. Use --network to specify a network.");
+                    log::warn!("Built on branch with no default network. Use --network to specify a network.");
                     None
                 }
             };

--- a/src/network.rs
+++ b/src/network.rs
@@ -72,17 +72,19 @@ pub struct InnerConfig {
 pub struct Config(InnerConfig);
 
 impl Config {
-    pub fn home(&self) -> Result<PathBuf> {
+    pub fn home(&self) -> Option<PathBuf> {
         if let Some(home) = self.home.as_ref() {
-            Ok(PathBuf::from(home))
+            Some(PathBuf::from(home))
         } else if let Some(chain_id) = self.chain_id.as_ref() {
-            Ok(orga::abci::Node::home(chain_id))
+            Some(orga::abci::Node::home(chain_id))
         } else {
-            Err(
-                orga::Error::App("Must specify --network, --home, or --chain-id".to_string())
-                    .into(),
-            )
+            None
         }
+    }
+
+    pub fn home_expect(&self) -> Result<PathBuf> {
+        self.home()
+            .ok_or_else(|| orga::Error::App("Cannot get home directory. Please specify either --network, --home, or --chain-id.".to_string()).into())
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,8 +1,10 @@
-use clap::{self, Parser};
-use serde::{Deserialize, Serialize};
-
 use crate::error::{Error, Result};
-use std::str::FromStr;
+use clap::{self, ArgMatches, Args, Command, CommandFactory, ErrorKind, FromArgMatches, Parser};
+use serde::{Deserialize, Serialize};
+use std::{
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -12,13 +14,13 @@ pub enum Network {
 }
 
 impl Network {
-    pub fn config(&self) -> Config {
+    pub fn config(&self) -> InnerConfig {
         let toml_src = match self {
             Self::Mainnet => panic!("Mainnet is not yet configured"),
             Self::Testnet => include_str!("../networks/testnet.toml"),
         };
 
-        let mut config: Config = toml::from_str(toml_src).unwrap();
+        let mut config: InnerConfig = toml::from_str(toml_src).unwrap();
 
         config.tendermint_flags = config
             .tendermint_flags
@@ -43,17 +45,113 @@ impl FromStr for Network {
     }
 }
 
-#[derive(Parser, Debug, Clone, Serialize, Deserialize)]
-pub struct Config {
-    #[clap(long)]
+#[derive(Parser, Debug, Default, Clone, Serialize, Deserialize)]
+pub struct InnerConfig {
+    #[clap(long, global = true)]
     pub state_sync_rpc: Vec<String>,
-    #[clap(long)]
+    #[clap(long, global = true)]
     pub chain_id: Option<String>,
-    #[clap(long)]
+    #[clap(long, global = true)]
     pub genesis: Option<String>,
-    #[clap(long)]
+    #[clap(long, global = true)]
     pub legacy_version: Option<String>,
-    pub tendermint_flags: Vec<String>,
-    #[clap(long)]
+    #[clap(long, global = true)]
     pub upgrade_time: Option<i64>,
+    #[clap(long, global = true)]
+    pub network: Option<Network>,
+
+    #[clap(global = true)]
+    pub tendermint_flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Config(InnerConfig);
+
+impl Deref for Config {
+    type Target = InnerConfig;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Config {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Parser for Config {}
+
+impl FromArgMatches for Config {
+    fn from_arg_matches(matches: &ArgMatches) -> std::result::Result<Self, clap::Error> {
+        let mut config = Self(Default::default());
+        config.update_from_arg_matches(matches)?;
+        Ok(config)
+    }
+
+    fn update_from_arg_matches(
+        &mut self,
+        matches: &ArgMatches,
+    ) -> std::result::Result<(), clap::Error> {
+        self.0.update_from_arg_matches(matches)?;
+
+        if let Some(network) = self.0.network {
+            let mut net_config = network.config();
+            let arg_config = &self.0;
+
+            if arg_config.chain_id.is_some() {
+                return Err(clap::Error::raw(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot use --chain-id with --network",
+                ));
+            }
+            if arg_config.genesis.is_some() {
+                return Err(clap::Error::raw(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot use --genesis with --network",
+                ));
+            }
+            if net_config.upgrade_time.is_some() && arg_config.upgrade_time.is_some() {
+                return Err(clap::Error::raw(
+                    ErrorKind::ArgumentConflict,
+                    "Cannot use --upgrade-time with --network",
+                ));
+            }
+
+            // TODO: deduplicate
+            net_config
+                .state_sync_rpc
+                .extend(arg_config.state_sync_rpc.iter().cloned());
+
+            // TODO: should all built-in tmflags get shadowed by user-specified tmflags?
+            net_config
+                .tendermint_flags
+                .extend(arg_config.tendermint_flags.iter().cloned());
+
+            self.0 = net_config;
+        }
+
+        Ok(())
+    }
+}
+
+impl CommandFactory for Config {
+    fn into_app<'help>() -> Command<'help> {
+        InnerConfig::into_app()
+    }
+
+    fn into_app_for_update<'help>() -> Command<'help> {
+        InnerConfig::into_app_for_update()
+    }
+}
+
+impl Args for Config {
+    fn augment_args(cmd: Command<'_>) -> Command<'_> {
+        InnerConfig::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command<'_>) -> Command<'_> {
+        InnerConfig::augment_args_for_update(cmd)
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,6 @@
 #[cfg(feature = "full")]
 use crate::app::App;
 use crate::app::Nom;
-use crate::app::CHAIN_ID;
 #[cfg(feature = "full")]
 use crate::bitcoin::adapter::Adapter;
 #[cfg(feature = "full")]
@@ -85,10 +84,10 @@ pub fn sleep(seconds: u64) {
     std::thread::sleep(duration);
 }
 
-pub fn generate_sign_doc(msg: sdk::Msg, nonce: u64) -> sdk::SignDoc {
+pub fn generate_sign_doc(chain_id: String, msg: sdk::Msg, nonce: u64) -> sdk::SignDoc {
     sdk::SignDoc {
         account_number: "0".to_string(),
-        chain_id: CHAIN_ID.to_string(),
+        chain_id,
         fee: sdk::Fee {
             amount: vec![sdk::Coin {
                 amount: "0".to_string(),

--- a/tests/node_spawn.rs
+++ b/tests/node_spawn.rs
@@ -1,0 +1,41 @@
+use orga::merk::MerkStore;
+
+#[test]
+fn fresh_local_network() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nomic"));
+    cmd.env("STOP_HEIGHT", "2");
+    cmd.args(["start", "--home", home.to_str().unwrap()]);
+
+    let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap(), 138);
+
+    let package_ver = env!("CARGO_PKG_VERSION");
+    assert!(home.join(format!("bin/nomic-{}", package_ver)).exists());
+    assert!(home.join("tendermint/config/genesis.json").exists());
+
+    {
+        let store = MerkStore::new(home.join("merk"));
+        assert_eq!(
+            store.merk().get_aux(b"height").unwrap().unwrap(),
+            2u64.to_be_bytes().to_vec(),
+        );
+    }
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nomic"));
+    cmd.env("STOP_HEIGHT", "4");
+    cmd.args(["start", "--home", home.to_str().unwrap()]);
+
+    let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap(), 138);
+
+    {
+        let store = MerkStore::new(home.join("merk"));
+        assert_eq!(
+            store.merk().get_aux(b"height").unwrap().unwrap(),
+            4u64.to_be_bytes().to_vec(),
+        );
+    }
+}

--- a/tests/node_spawn.rs
+++ b/tests/node_spawn.rs
@@ -90,3 +90,28 @@ fn migrate() {
         );
     }
 }
+
+#[ignore]
+#[serial_test::serial]
+#[test]
+fn testnet() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nomic"));
+    cmd.env("NOMIC_EXIT_ON_START", "1");
+    cmd.args([
+        "start",
+        "--network",
+        "testnet",
+        "--home",
+        home.to_str().unwrap(),
+    ]);
+
+    let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap(), 139);
+
+    let package_ver = env!("CARGO_PKG_VERSION");
+    assert!(home.join(format!("bin/nomic-{}", package_ver)).exists());
+    assert!(home.join("tendermint/config/genesis.json").exists());
+}

--- a/tests/node_spawn.rs
+++ b/tests/node_spawn.rs
@@ -1,5 +1,7 @@
 use orga::merk::MerkStore;
 
+#[ignore]
+#[serial_test::serial]
 #[test]
 fn fresh_local_network() {
     let dir = tempfile::tempdir().unwrap();
@@ -11,6 +13,55 @@ fn fresh_local_network() {
 
     let output = cmd.spawn().unwrap().wait_with_output().unwrap();
     assert_eq!(output.status.code().unwrap(), 138);
+
+    let package_ver = env!("CARGO_PKG_VERSION");
+    assert!(home.join(format!("bin/nomic-{}", package_ver)).exists());
+    assert!(home.join("tendermint/config/genesis.json").exists());
+
+    {
+        let store = MerkStore::new(home.join("merk"));
+        assert_eq!(
+            store.merk().get_aux(b"height").unwrap().unwrap(),
+            2u64.to_be_bytes().to_vec(),
+        );
+    }
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nomic"));
+    cmd.env("STOP_HEIGHT", "4");
+    cmd.args(["start", "--home", home.to_str().unwrap()]);
+
+    let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap(), 138);
+
+    {
+        let store = MerkStore::new(home.join("merk"));
+        assert_eq!(
+            store.merk().get_aux(b"height").unwrap().unwrap(),
+            4u64.to_be_bytes().to_vec(),
+        );
+    }
+}
+
+#[ignore]
+#[serial_test::serial]
+#[test]
+fn migrate() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nomic"));
+    cmd.env("STOP_HEIGHT", "2");
+    cmd.args([
+        "start",
+        "--home",
+        home.to_str().unwrap(),
+        "--legacy-version",
+        "*",
+    ]);
+
+    let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+    assert_eq!(output.status.code().unwrap(), 138);
+    println!("Exited first spawn");
 
     let package_ver = env!("CARGO_PKG_VERSION");
     assert!(home.join(format!("bin/nomic-{}", package_ver)).exists());

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -635,11 +635,22 @@ pub async fn ibc_transfer_out(
     .await
 }
 
-async fn gen_call_bytes(
-    chain_id: String,
-    address: String,
-    msg: sdk::Msg,
-) -> Result<String, JsError> {
+fn local_storage_chain_id() -> String {
+    let window = web_sys::window().expect("no global `window` exists");
+    let keplr = window.get("keplr").expect("no `keplr` in global `window`");
+
+    window
+        .local_storage()
+        .expect("no `localStorage` in global `window`")
+        .expect("no `localStorage` in global `window`")
+        .get("orga/chainid")
+        .expect("Could not load from local storage")
+        .expect("localStorage['orga/chainid'] is not set")
+}
+
+async fn gen_call_bytes(address: String, msg: sdk::Msg) -> Result<String, JsError> {
+    let chain_id = local_storage_chain_id();
+
     let address = address
         .parse()
         .map_err(|e| Error::Wasm(format!("{:?}", e)))?;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -10,7 +10,7 @@ use nomic::orga::Error as OrgaError;
 use std::str::FromStr;
 // use crate::web_client::WebClient;
 use js_sys::{Array, Uint8Array};
-use nomic::app::{App, DepositCommitment, InnerApp, Nom, CHAIN_ID};
+use nomic::app::{App, DepositCommitment, InnerApp, Nom};
 use nomic::bitcoin::Nbtc;
 use nomic::orga::client::wallet::Unsigned;
 use nomic::orga::client::AppClient;
@@ -635,7 +635,11 @@ pub async fn ibc_transfer_out(
     .await
 }
 
-async fn gen_call_bytes(address: String, msg: sdk::Msg) -> Result<String, JsError> {
+async fn gen_call_bytes(
+    chain_id: String,
+    address: String,
+    msg: sdk::Msg,
+) -> Result<String, JsError> {
     let address = address
         .parse()
         .map_err(|e| Error::Wasm(format!("{:?}", e)))?;
@@ -645,7 +649,7 @@ async fn gen_call_bytes(address: String, msg: sdk::Msg) -> Result<String, JsErro
         .await?;
     let sign_doc = sdk::SignDoc {
         account_number: "0".to_string(),
-        chain_id: CHAIN_ID.to_string(),
+        chain_id,
         //does this fee have to be a vec
         fee: sdk::Fee {
             amount: vec![sdk::Coin {


### PR DESCRIPTION
This PR improves the CLI and systems related to node spawning:
- Build legacy node and write it to binary store so nodes fresh nodes can start while an upgrade is happening, and nodes can be guaranteed to have all required fixes when upgrading without having to do multiple build steps
- Run legacy binary for all subcommands when network hasn't yet upgraded
- Exit signer and relayer when a node migration is detected, so they can move to the updated binary
- Allow using node config for all subcommands
- Remove remaining uses of `CHAIN_ID` constant
- Add various test options
- Changed `legacy_version` config option to a semver req rather than an exact string match
- Fix missing Tokio runtime for `--signal-version`
- Various tweaks making node config more robust