### PR TITLE
Migration QA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=52493d1b9b8216f9d16fd7b39c5f511a96fc3f9f#52493d1b9b8216f9d16fd7b39c5f511a96fc3f9f"
+source = "git+https://github.com/nomic-io/orga.git?rev=c57d11dfebb6bda9abaa343ad38ebf1ff0310009#c57d11dfebb6bda9abaa343ad38ebf1ff0310009"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=52493d1b9b8216f9d16fd7b39c5f511a96fc3f9f#52493d1b9b8216f9d16fd7b39c5f511a96fc3f9f"
+source = "git+https://github.com/nomic-io/orga.git?rev=c57d11dfebb6bda9abaa343ad38ebf1ff0310009#c57d11dfebb6bda9abaa343ad38ebf1ff0310009"
 dependencies = [
  "darling 0.14.4",
  "heck 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=faa15d00862b5ad395f65265631a9093bc3cd140#faa15d00862b5ad395f65265631a9093bc3cd140"
+source = "git+https://github.com/nomic-io/orga.git?rev=bf60998dc539fe0f962b1ce91a13e8d72416294d#bf60998dc539fe0f962b1ce91a13e8d72416294d"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=faa15d00862b5ad395f65265631a9093bc3cd140#faa15d00862b5ad395f65265631a9093bc3cd140"
+source = "git+https://github.com/nomic-io/orga.git?rev=bf60998dc539fe0f962b1ce91a13e8d72416294d#bf60998dc539fe0f962b1ce91a13e8d72416294d"
 dependencies = [
  "darling 0.14.4",
  "heck 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=c57d11dfebb6bda9abaa343ad38ebf1ff0310009#c57d11dfebb6bda9abaa343ad38ebf1ff0310009"
+source = "git+https://github.com/nomic-io/orga.git?rev=faa15d00862b5ad395f65265631a9093bc3cd140#faa15d00862b5ad395f65265631a9093bc3cd140"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=c57d11dfebb6bda9abaa343ad38ebf1ff0310009#c57d11dfebb6bda9abaa343ad38ebf1ff0310009"
+source = "git+https://github.com/nomic-io/orga.git?rev=faa15d00862b5ad395f65265631a9093bc3cd140#faa15d00862b5ad395f65265631a9093bc3cd140"
 dependencies = [
  "darling 0.14.4",
  "heck 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }
 bitcoind = { version = "0.21.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "c57d11dfebb6bda9abaa343ad38ebf1ff0310009", features = ["merk-verify"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "faa15d00862b5ad395f65265631a9093bc3cd140", features = ["merk-verify"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }
 bitcoind = { version = "0.21.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "faa15d00862b5ad395f65265631a9093bc3cd140", features = ["merk-verify"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "bf60998dc539fe0f962b1ce91a13e8d72416294d", features = ["merk-verify"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.28.1", features = ["use-serde"] }
 bitcoind = { version = "0.21.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "52493d1b9b8216f9d16fd7b39c5f511a96fc3f9f", features = ["merk-verify"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "c57d11dfebb6bda9abaa343ad38ebf1ff0310009", features = ["merk-verify"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/src/airdrop.rs
+++ b/src/airdrop.rs
@@ -33,10 +33,6 @@ pub struct Airdrop {
 #[cfg(feature = "testnet")]
 #[orga(version = 1)]
 pub struct Airdrop {
-    #[orga(version(V0))]
-    accounts: Map<Address, Account>,
-
-    #[orga(version(V1))]
     accounts: Map<Address, Account>,
 }
 
@@ -357,26 +353,13 @@ impl MigrateFrom<AirdropV0> for AirdropV1 {
     }
 }
 
+#[cfg(not(feature = "testnet"))]
 #[orga(version = 1)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Account {
-    #[cfg(not(feature = "testnet"))]
     #[orga(version(V0))]
     pub claimable: Amount,
 
-    #[cfg(feature = "testnet")]
-    #[orga(version(V0))]
-    pub airdrop1: Part,
-    #[cfg(feature = "testnet")]
-    #[orga(version(V0))]
-    pub btc_deposit: Part,
-    #[cfg(feature = "testnet")]
-    #[orga(version(V0))]
-    pub btc_withdraw: Part,
-    #[cfg(feature = "testnet")]
-    #[orga(version(V0))]
-    pub ibc_transfer: Part,
-
     #[orga(version(V1))]
     pub airdrop1: Part,
     #[orga(version(V1))]
@@ -385,17 +368,23 @@ pub struct Account {
     pub btc_withdraw: Part,
     #[orga(version(V1))]
     pub ibc_transfer: Part,
-    #[cfg(not(feature = "testnet"))]
     #[orga(version(V1))]
     pub testnet_participation: Part,
 }
 
+#[cfg(feature = "testnet")]
+#[orga(version = 1)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Account {
+    pub airdrop1: Part,
+    pub btc_deposit: Part,
+    pub btc_withdraw: Part,
+    pub ibc_transfer: Part,
+}
+
 impl Account {
     pub fn is_empty(&self) -> bool {
-        self.airdrop1.is_empty()
-            && self.btc_deposit.is_empty()
-            && self.btc_withdraw.is_empty()
-            && self.ibc_transfer.is_empty()
+        self == &Self::default()
     }
 }
 
@@ -422,7 +411,7 @@ impl MigrateFrom<AccountV0> for AccountV1 {
 }
 
 #[orga]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Part {
     pub locked: u64,
     pub claimable: u64,
@@ -447,7 +436,7 @@ impl Part {
     }
 
     pub fn is_empty(&self) -> bool {
-        (self.locked + self.claimable + self.claimed) == 0
+        self == &Self::default()
     }
 
     pub fn total(&self) -> u64 {

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,7 @@ pub const CONSENSUS_VERSION: u8 = 0;
 pub type AppV0 = DefaultPlugins<Nom, InnerAppV0, CHAIN_ID>;
 pub type App = DefaultPlugins<Nom, InnerApp, CHAIN_ID>;
 
-#[derive(State, Debug, Clone, Encode, Decode, Default, MigrateFrom)]
+#[derive(State, Debug, Clone, Encode, Decode, Default, MigrateFrom, Serialize)]
 pub struct Nom(());
 impl Symbol for Nom {
     const INDEX: u8 = 69;

--- a/src/app/migrations.rs
+++ b/src/app/migrations.rs
@@ -7,12 +7,7 @@ use orga::{
 impl MigrateFrom<InnerAppV0> for InnerAppV1 {
     #[allow(unused_mut)]
     fn migrate_from(mut other: InnerAppV0) -> orga::Result<Self> {
-        #[cfg(not(feature = "testnet"))]
-        other
-            .airdrop
-            .init_from_airdrop2_csv(include_bytes!("../../airdrop2_snapshot.csv"))?;
-
-        Ok(Self {
+        let mut app = Self {
             accounts: other.accounts.migrate_into()?,
             staking: other.staking.migrate_into()?,
             airdrop: other.airdrop,
@@ -27,6 +22,12 @@ impl MigrateFrom<InnerAppV0> for InnerAppV1 {
             #[cfg(feature = "testnet")]
             ibc: orga::ibc::Ibc::default(),
             upgrade: Upgrade::default(),
-        })
+        };
+
+        #[cfg(not(feature = "testnet"))]
+        app.airdrop
+            .init_from_airdrop2_csv(include_bytes!("../../airdrop2_snapshot.csv"))?;
+
+        Ok(app)
     }
 }

--- a/src/bitcoin/adapter.rs
+++ b/src/bitcoin/adapter.rs
@@ -6,10 +6,11 @@ use orga::prelude::*;
 use orga::state::State;
 use orga::store::Store;
 use orga::Result as OrgaResult;
+use serde::Serialize;
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Adapter<T> {
     inner: T,
 }

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -21,6 +21,7 @@ use orga::{
     state::State,
     Error as OrgaError, Result as OrgaResult,
 };
+use serde::Serialize;
 use std::convert::TryFrom;
 
 pub const MIN_CHECKPOINT_INTERVAL: u64 = 60 * 5;
@@ -30,7 +31,7 @@ pub const MAX_OUTPUTS: u64 = 200;
 pub const FEE_RATE: u64 = 1;
 pub const MAX_AGE: u64 = 60 * 60 * 24 * 7 * 3;
 
-#[derive(Debug, Encode, Decode, Default)]
+#[derive(Debug, Encode, Decode, Default, Serialize)]
 pub enum CheckpointStatus {
     #[default]
     Building,

--- a/src/bitcoin/header_queue.rs
+++ b/src/bitcoin/header_queue.rs
@@ -14,6 +14,7 @@ use orga::state::State;
 use orga::store::Store;
 use orga::Error as OrgaError;
 use orga::Result as OrgaResult;
+use serde::Serialize;
 
 const MAX_LENGTH: u64 = 4032;
 const MAX_RELAY: u64 = 25;
@@ -175,7 +176,7 @@ impl WorkHeader {
 
 // TODO: implement trait that returns constants for bitcoin::Network variants
 
-#[derive(Clone, Encode, Decode, State, MigrateFrom)]
+#[derive(Clone, Encode, Decode, State, MigrateFrom, Serialize)]
 pub struct Config {
     pub max_length: u64,
     pub max_time_increase: u32,
@@ -254,7 +255,7 @@ impl Config {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub struct Network(bitcoin::Network);
 
 impl MigrateFrom for Network {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -27,6 +27,7 @@ use orga::query::Query;
 use orga::state::State;
 use orga::store::Store;
 use orga::{Error as OrgaError, Result as OrgaResult};
+use serde::Serialize;
 use signatory::SignatorySet;
 use txid_set::OutpointSet;
 
@@ -41,7 +42,7 @@ pub mod signer;
 pub mod threshold_sig;
 pub mod txid_set;
 
-#[derive(State, Debug, Clone, Encode, Decode, Default, MigrateFrom)]
+#[derive(State, Debug, Clone, Encode, Decode, Default, MigrateFrom, Serialize)]
 pub struct Nbtc(());
 impl Symbol for Nbtc {
     const INDEX: u8 = 21;
@@ -78,7 +79,7 @@ pub struct Bitcoin {
 
 pub type ConsensusKey = [u8; 32];
 
-#[derive(Call, Query, Clone, Debug, Client, PartialEq)]
+#[derive(Call, Query, Clone, Debug, Client, PartialEq, Serialize)]
 pub struct Xpub(ExtendedPubKey);
 
 impl MigrateFrom for Xpub {

--- a/src/bitcoin/threshold_sig.rs
+++ b/src/bitcoin/threshold_sig.rs
@@ -14,11 +14,12 @@ use orga::migrate::MigrateFrom;
 use orga::query::Query;
 use orga::state::State;
 use orga::{Error, Result};
+use serde::Serialize;
 
 pub type Message = [u8; MESSAGE_SIZE];
 
-#[derive(Encode, Decode, State, Debug, Clone, Deref, From, Copy, MigrateFrom)]
-pub struct Signature([u8; COMPACT_SIGNATURE_SIZE]);
+#[derive(Encode, Decode, State, Debug, Clone, Deref, From, Copy, MigrateFrom, Serialize)]
+pub struct Signature(#[serde(serialize_with = "<[_]>::serialize")] [u8; COMPACT_SIGNATURE_SIZE]);
 
 #[derive(
     Encode,
@@ -35,8 +36,9 @@ pub struct Signature([u8; COMPACT_SIGNATURE_SIZE]);
     Ord,
     MigrateFrom,
     Client,
+    Serialize,
 )]
-pub struct Pubkey([u8; PUBLIC_KEY_SIZE]);
+pub struct Pubkey(#[serde(serialize_with = "<[_]>::serialize")] [u8; PUBLIC_KEY_SIZE]);
 
 impl Next for Pubkey {
     fn next(&self) -> Option<Self> {


### PR DESCRIPTION
This PR adds an `export` CLI subcommand to dump entire state as JSON which can be inspected for QA and debugging, and can be diffed with states exported from earlier versions to ensure migrations happened correctly.

This PR is blocking on https://github.com/nomic-io/orga/pull/173 being merged.