### PR TITLE
Migrate fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,6 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=25f4b09411468a979b6dce642d2904ecf6555731#25f4b09411468a979b6dce642d2904ecf6555731"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2617,7 +2616,6 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=25f4b09411468a979b6dce642d2904ecf6555731#25f4b09411468a979b6dce642d2904ecf6555731"
 dependencies = [
  "darling",
  "heck 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "5.1.0"
+version = "5.1.1"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.29.2", features = ["serde", "rand"] }
 bitcoind = { version = "0.27.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "25f4b09411468a979b6dce642d2904ecf6555731", features = ["merk-verify"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "19d6718a574e882922418da293e4dcd82d800184", features = ["merk-verify"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/networks/testnet.toml
+++ b/networks/testnet.toml
@@ -6,7 +6,7 @@ state_sync_rpc = [
 tendermint_flags = [
     "--p2p.seeds",
     """
-        6a6c1af342ce45d550e30ddc187bbbb81167d9b8@167.99.228.240:26656,\
+        6a6c1af342ce45d550e30ddc187bbbb81167d9b8@147.182.171.216:26656,\
     """,
 ]
 

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",


### PR DESCRIPTION
This hotfix patch upgrades Orga to fix an issue where nodes which had gone through a previous migration were skipping the migration step for subsequent upgrades.