### PR TITLE
Post v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.0.0"
+version = "6.0.1"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 semver = "1.0.18"
 
 [features]
-default = ["full", "feat-ibc", "legacy-bin"]
+default = ["full", "feat-ibc"]
 full = ["bitcoind", "bitcoincore-rpc-async", "clap", "tokio", "orga/merk-full", "orga/abci", "orga/state-sync", "csv", "warp", "rand", "reqwest", "tendermint-rpc", "home"]
 feat-ibc = ["orga/feat-ibc"]
 testnet = []

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",


### PR DESCRIPTION
This PR removes `legacy-bin` as a default feature, as it is not needed once the V6 upgrade activates. In the future, instead of controlling this through a timely PR, the code could detect the need for the legacy binary by making a light client query to the network.