### PR TITLE
Legacy bin fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.0.1"
+version = "6.0.2"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -403,7 +403,12 @@ fn legacy_bin(config: &nomic::network::Config) -> Result<Option<PathBuf>> {
                 let utd = if let Some(store_ver) = store_ver {
                     store_ver == vec![InnerApp::CONSENSUS_VERSION]
                 } else {
-                    false
+                    let store_ver = store.merk().get(b"/version").unwrap();
+                    if let Some(store_ver) = store_ver {
+                        store_ver == vec![1, InnerApp::CONSENSUS_VERSION]
+                    } else {
+                        false
+                    }
                 };
                 let initialized = store.merk().get_aux(b"height").unwrap().is_some();
                 (utd, initialized)


### PR DESCRIPTION
Fixes check for whether to run legacy bin for nodes that have never undergone a migration.