### PR TITLE
Support specifying RPC address via --node in CLI commands

### DIFF
--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -3,7 +3,7 @@ extern crate rocket;
 
 use nomic::{
     app::{App, InnerApp, Nom},
-    app_client_testnet,
+    app_client,
     orga::{
         coins::{Address, Amount, Decimal},
         plugins::*,
@@ -27,7 +27,7 @@ lazy_static::lazy_static! {
 async fn bank_balances(address: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = address.parse().unwrap();
 
-    let balance: u64 = app_client_testnet()
+    let balance: u64 = app_client()
         .query(|app| app.accounts.balance(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
@@ -55,7 +55,7 @@ async fn bank_balances(address: &str) -> Result<Value, BadRequest<String>> {
 async fn bank_balances_2(address: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = address.parse().unwrap();
 
-    let balance: u64 = app_client_testnet()
+    let balance: u64 = app_client()
         .query(|app| app.accounts.balance(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
@@ -76,13 +76,13 @@ async fn bank_balances_2(address: &str) -> Result<Value, BadRequest<String>> {
 async fn auth_accounts(addr_str: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = addr_str.parse().unwrap();
 
-    let balance: u64 = app_client_testnet()
+    let balance: u64 = app_client()
         .query(|app| app.accounts.balance(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
         .into();
 
-    let mut nonce: u64 = app_client_testnet()
+    let mut nonce: u64 = app_client()
         .query_root(|app| app.inner.inner.borrow().inner.inner.inner.nonce(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
@@ -111,13 +111,13 @@ async fn auth_accounts(addr_str: &str) -> Result<Value, BadRequest<String>> {
 async fn auth_accounts2(addr_str: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = addr_str.parse().unwrap();
 
-    let balance: u64 = app_client_testnet()
+    let balance: u64 = app_client()
         .query(|app| app.accounts.balance(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
         .into();
 
-    let mut nonce: u64 = app_client_testnet()
+    let mut nonce: u64 = app_client()
         .query_root(|app| app.inner.inner.borrow().inner.inner.inner.nonce(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?
@@ -286,7 +286,7 @@ async fn query(query: &str, height: Option<u32>) -> Result<String, BadRequest<St
 async fn staking_delegators_delegations(address: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = address.parse().unwrap();
 
-    let delegations = app_client_testnet()
+    let delegations = app_client()
         .query(|app| app.staking.delegations(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?;
@@ -315,7 +315,7 @@ async fn staking_delegators_delegations(address: &str) -> Result<Value, BadReque
 async fn staking_delegators_delegations_2(address: &str) -> Result<Value, BadRequest<String>> {
     let address: Address = address.parse().unwrap();
 
-    let delegations = app_client_testnet()
+    let delegations = app_client()
         .query(|app| app.staking.delegations(address))
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?;
@@ -439,7 +439,7 @@ async fn distribution_delegatrs_rewards_2(_address: &str) -> Value {
 
 #[get("/cosmos/mint/v1beta1/inflation")]
 async fn minting_inflation() -> Result<Value, BadRequest<String>> {
-    let validators = app_client_testnet()
+    let validators = app_client()
         .query(|app| app.staking.all_validators())
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?;
@@ -459,7 +459,7 @@ async fn minting_inflation() -> Result<Value, BadRequest<String>> {
 
 #[get("/minting/inflation")]
 async fn minting_inflation_2() -> Result<Value, BadRequest<String>> {
-    let validators = app_client_testnet()
+    let validators = app_client()
         .query(|app| app.staking.all_validators())
         .await
         .map_err(|e| BadRequest(Some(format!("{:?}", e))))?;

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -3,11 +3,12 @@ extern crate rocket;
 
 use nomic::{
     app::{App, InnerApp, Nom},
-    app_client,
     orga::{
+        client::{wallet::Unsigned, AppClient},
         coins::{Address, Amount, Decimal},
         plugins::*,
         query::Query,
+        tendermint::client::HttpClient,
     },
 };
 use rocket::response::status::BadRequest;
@@ -21,6 +22,10 @@ use tm::Client as _;
 
 lazy_static::lazy_static! {
     static ref QUERY_CACHE: Arc<RwLock<HashMap<String, (u64, String)>>> = Arc::new(RwLock::new(HashMap::new()));
+}
+
+fn app_client() -> AppClient<InnerApp, InnerApp, HttpClient, Nom, Unsigned> {
+    nomic::app_client("http://localhost:26657")
 }
 
 #[get("/cosmos/bank/v1beta1/balances/<address>")]

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1487,15 +1487,19 @@ impl ExportCmd {
 }
 
 #[derive(Parser, Debug)]
-pub struct UpgradeStatusCmd {}
+pub struct UpgradeStatusCmd {
+    #[clap(flatten)]
+    config: nomic::network::Config,
+}
 
 impl UpgradeStatusCmd {
     async fn run(&self) -> Result<()> {
         use orga::coins::staking::ValidatorQueryInfo;
         use orga::coins::VersionedAddress;
         use std::collections::{HashMap, HashSet};
-        let client = app_client();
-        let tm_client = tendermint_rpc::HttpClient::new("http://localhost:26657").unwrap();
+        let client = self.config.client();
+        let tm_client =
+            tendermint_rpc::HttpClient::new(self.config.node.as_ref().unwrap().as_str()).unwrap();
         let curr_height = tm_client
             .status()
             .await

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1347,6 +1347,9 @@ impl WithdrawCmd {
 pub struct IbcDepositNbtcCmd {
     to: Address,
     amount: u64,
+
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 #[cfg(feature = "testnet")]
@@ -1368,6 +1371,9 @@ impl IbcDepositNbtcCmd {
 #[derive(Parser, Debug)]
 pub struct IbcWithdrawNbtcCmd {
     amount: u64,
+
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 #[cfg(feature = "testnet")]
@@ -1390,6 +1396,9 @@ impl IbcWithdrawNbtcCmd {
 pub struct GrpcCmd {
     #[clap(default_value_t = 9001)]
     port: u16,
+
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 #[cfg(feature = "testnet")]
@@ -1397,7 +1406,8 @@ impl GrpcCmd {
     async fn run(&self) -> Result<()> {
         use orga::ibc::GrpcOpts;
         orga::ibc::start_grpc(
-            || self.config.client().sub(|app| app.ibc),
+            // TODO: support configuring RPC address
+            || nomic::app_client("http://localhost:26657").sub(|app| app.ibc),
             &GrpcOpts {
                 host: "127.0.0.1".to_string(),
                 port: self.port,
@@ -1417,6 +1427,9 @@ pub struct IbcTransferCmd {
     channel_id: String,
     port_id: String,
     denom: String,
+
+    #[clap(flatten)]
+    config: nomic::network::Config,
 }
 
 #[cfg(feature = "testnet")]

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1342,6 +1342,17 @@ impl CheckpointQueue {
 
 #[cfg(test)]
 mod test {
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use bitcoin::{
+        util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey},
+        OutPoint, PubkeyHash, Script, Txid,
+    };
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use rand::Rng;
+
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use crate::bitcoin::{signatory::Signatory, threshold_sig::Share};
+
     use super::*;
 
     fn push_bitcoin_tx_output(tx: &mut BitcoinTx, value: u64) {
@@ -1433,7 +1444,7 @@ mod test {
                     power: 100,
                     sig: None,
                 },
-            );
+            )?;
             Ok::<_, Error>(input)
         };
 
@@ -1452,7 +1463,7 @@ mod test {
                     power: 100,
                     sig: Some(Signature([123; 64])),
                 },
-            );
+            )?;
             input.signatures.signed = 100;
             Ok::<_, Error>(input)
         };

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1342,14 +1342,6 @@ impl CheckpointQueue {
 
 #[cfg(test)]
 mod test {
-    use bitcoin::{
-        util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey},
-        OutPoint, PubkeyHash, Script, Txid,
-    };
-    use rand::Rng;
-
-    use crate::bitcoin::{signatory::Signatory, threshold_sig::Share};
-
     use super::*;
 
     fn push_bitcoin_tx_output(tx: &mut BitcoinTx, value: u64) {

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -297,7 +297,7 @@ impl Relayer {
 
         let mut relayed = HashSet::new();
         loop {
-            let disbursal_txs = app_client()
+            let disbursal_txs = app_client(&self.app_client_addr)
                 .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs()?))
                 .await?;
 

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -1,7 +1,7 @@
 use super::signatory::Signatory;
 use super::SignatorySet;
 use crate::app::DepositCommitment;
-use crate::app_client_testnet;
+use crate::app_client;
 use crate::bitcoin::{adapter::Adapter, header_queue::WrappedHeader};
 use crate::error::Error;
 use crate::error::Result;
@@ -34,20 +34,22 @@ const HEADER_BATCH_SIZE: usize = 250;
 
 pub struct Relayer {
     btc_client: BitcoinRpcClient,
+    app_client_addr: String,
 
     scripts: Option<WatchedScriptStore>,
 }
 
 impl Relayer {
-    pub fn new(btc_client: BitcoinRpcClient) -> Self {
+    pub fn new(btc_client: BitcoinRpcClient, app_client_addr: String) -> Self {
         Relayer {
             btc_client,
+            app_client_addr,
             scripts: None,
         }
     }
 
     async fn sidechain_block_hash(&self) -> Result<BlockHash> {
-        let hash = app_client_testnet()
+        let hash = app_client(&self.app_client_addr)
             .query(|app| Ok(app.bitcoin.headers.hash()?))
             .await?;
         let hash = BlockHash::from_slice(hash.as_slice())?;
@@ -95,7 +97,7 @@ impl Relayer {
     pub async fn start_deposit_relay<P: AsRef<Path>>(mut self, store_path: P) -> Result<()> {
         info!("Starting deposit relay...");
 
-        let scripts = WatchedScriptStore::open(store_path).await?;
+        let scripts = WatchedScriptStore::open(store_path, &self.app_client_addr).await?;
         self.scripts = Some(scripts);
 
         let (server, mut recv) = self.create_address_server();
@@ -121,6 +123,9 @@ impl Relayer {
 
         let sigsets = Arc::new(Mutex::new(BTreeMap::new()));
 
+        // TODO: pass into closures more cleanly
+        let app_client_addr: &'static str = self.app_client_addr.clone().leak();
+
         // TODO: configurable listen address
         use bytes::Bytes;
         use warp::Filter;
@@ -145,7 +150,7 @@ impl Relayer {
                     let sigset = match sigsets.get(&query.sigset_index) {
                         Some(sigset) => sigset,
                         None => {
-                            app_client_testnet()
+                            app_client(app_client_addr)
                                 .query(|app| {
                                     let sigset = app
                                         .bitcoin
@@ -191,8 +196,8 @@ impl Relayer {
             );
 
         let sigset_route = warp::path("sigset")
-            .and_then(async move || {
-                let sigset = app_client_testnet()
+            .and_then(move || async {
+                let sigset = app_client(app_client_addr)
                     .query(|app| {
                         let sigset: RawSignatorySet =
                             app.bitcoin.checkpoints.active_sigset()?.into();
@@ -292,7 +297,7 @@ impl Relayer {
 
         let mut relayed = HashSet::new();
         loop {
-            let disbursal_txs = app_client_testnet()
+            let disbursal_txs = app_client()
                 .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs()?))
                 .await?;
 
@@ -346,7 +351,7 @@ impl Relayer {
     }
 
     async fn relay_checkpoints(&mut self) -> Result<()> {
-        let last_checkpoint = app_client_testnet()
+        let last_checkpoint = app_client(&self.app_client_addr)
             .query(|app| Ok(app.bitcoin.checkpoints.last_completed_tx()?))
             .await?;
         info!("Last checkpoint tx: {}", last_checkpoint.txid());
@@ -354,7 +359,7 @@ impl Relayer {
         let mut relayed = HashSet::new();
 
         loop {
-            let txs = app_client_testnet()
+            let txs = app_client(&self.app_client_addr)
                 .query(|app| Ok(app.bitcoin.checkpoints.completed_txs()?))
                 .await?;
             for tx in txs {
@@ -389,7 +394,7 @@ impl Relayer {
         recv: &mut Receiver<(DepositCommitment, u32)>,
     ) -> Result<()> {
         while let Ok((addr, sigset_index)) = recv.try_recv() {
-            let sigset_res = app_client_testnet()
+            let sigset_res = app_client(&self.app_client_addr)
                 .query(|app| Ok(app.bitcoin.checkpoints.get(sigset_index)?.sigset.clone()))
                 .await;
             let sigset = match sigset_res {
@@ -479,7 +484,7 @@ impl Relayer {
         let outpoint = (txid.into_inner(), output.vout);
         let dest = output.dest.clone();
         let vout = output.vout;
-        let contains_outpoint = app_client_testnet()
+        let contains_outpoint = app_client(&self.app_client_addr)
             .query(|app| app.bitcoin.processed_outpoints.contains(outpoint))
             .await?;
 
@@ -499,7 +504,7 @@ impl Relayer {
             let tx = Adapter::new(tx);
             let proof = Adapter::new(proof);
 
-            let res = app_client_testnet()
+            let res = app_client(&self.app_client_addr)
                 .call(
                     move |app| {
                         build_call!(app.relay_deposit(
@@ -558,13 +563,13 @@ impl Relayer {
             batch[0].height(),
             batch.len(),
         );
-        app_client_testnet()
+        app_client(&self.app_client_addr)
             .call(
                 |app| build_call!(app.bitcoin.headers.add(batch.clone().into_iter().collect())),
                 |app| build_call!(app.app_noop()),
             )
             .await?;
-        let res = app_client_testnet()
+        let res = app_client(&self.app_client_addr)
             .call(
                 move |app| build_call!(app.bitcoin.headers.add(batch.clone().into())),
                 |app| build_call!(app.app_noop()),
@@ -757,11 +762,11 @@ pub struct WatchedScriptStore {
 }
 
 impl WatchedScriptStore {
-    pub async fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub async fn open<P: AsRef<Path>>(path: P, app_client_addr: &str) -> Result<Self> {
         let path = path.as_ref().join("watched-addrs.csv");
 
         let mut scripts = WatchedScripts::new();
-        Self::maybe_load(&path, &mut scripts).await?;
+        Self::maybe_load(&path, &mut scripts, app_client_addr).await?;
 
         let tmp_path = path.with_file_name("watched-addrs-tmp.csv");
         let mut tmp_file = File::create(&tmp_path)?;
@@ -779,7 +784,11 @@ impl WatchedScriptStore {
         Ok(WatchedScriptStore { scripts, file })
     }
 
-    async fn maybe_load<P: AsRef<Path>>(path: P, scripts: &mut WatchedScripts) -> Result<()> {
+    async fn maybe_load<P: AsRef<Path>>(
+        path: P,
+        scripts: &mut WatchedScripts,
+        app_client_addr: &str,
+    ) -> Result<()> {
         let file = match File::open(&path) {
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(e) => return Err(e.into()),
@@ -787,7 +796,7 @@ impl WatchedScriptStore {
         };
 
         let mut sigsets = BTreeMap::new();
-        app_client_testnet()
+        app_client(app_client_addr)
             .query(|app| {
                 for (index, checkpoint) in app.bitcoin.checkpoints.all()? {
                     sigsets.insert(index, checkpoint.sigset.clone());
@@ -855,7 +864,7 @@ mod tests {
             BitcoinRpcClient::new(&bitcoind_url, Auth::CookieFile(bitcoin_cookie_file)).unwrap();
 
         bitcoind.client.generate_to_address(25, &address).unwrap();
-        let relayer = Relayer::new(rpc_client);
+        let relayer = Relayer::new(rpc_client, "http://localhost:26657".to_string());
 
         let block_hash = bitcoind.client.get_block_hash(30).unwrap();
         let headers = relayer.get_header_batch(block_hash).unwrap();
@@ -887,7 +896,7 @@ mod tests {
             BitcoinRpcClient::new(&bitcoind_url, Auth::CookieFile(bitcoin_cookie_file)).unwrap();
 
         bitcoind.client.generate_to_address(7, &address).unwrap();
-        let relayer = Relayer::new(rpc_client);
+        let relayer = Relayer::new(rpc_client, "http://localhost:26657".to_string());
         let block_hash = bitcoind.client.get_block_hash(30).unwrap();
         let headers = relayer.get_header_batch(block_hash).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(specialization)]
 #![feature(type_alias_impl_trait)]
 #![feature(async_closure)]
+#![feature(string_leak)]
 
 #[cfg(feature = "full")]
 use orga::{
@@ -19,12 +20,15 @@ pub mod app;
 pub mod bitcoin;
 pub mod error;
 pub mod incentives;
+#[cfg(feature = "full")]
 pub mod network;
+#[cfg(feature = "full")]
 pub mod utils;
 
 #[cfg(feature = "full")]
-pub fn app_client_testnet(
+pub fn app_client(
+    addr: &str,
 ) -> AppClient<app::InnerApp, app::InnerApp, HttpClient, app::Nom, Unsigned> {
-    let client = HttpClient::new("http://localhost:26657").unwrap();
+    let client = HttpClient::new(addr).unwrap();
     AppClient::new(client, Unsigned)
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -106,9 +106,7 @@ impl Config {
     }
 
     pub fn client(&self) -> AppClient<InnerApp, InnerApp, HttpClient, Nom, Unsigned> {
-        // TODO: get port from config for default
-        let default_addr = "http://localhost:26657".to_string();
-        let node = self.args.node.as_ref().unwrap_or(&default_addr);
+        let node = self.args.node.as_ref().unwrap();
         crate::app_client(node)
     }
 }
@@ -214,6 +212,11 @@ impl FromArgMatches for Config {
             } else {
                 self.args.chain_id = Some(gensis_cid.to_string());
             }
+        }
+
+        if self.args.node.is_none() {
+            // TODO: get port from Tendermint config.toml for default
+            self.args.node = Some("http://localhost:26657".to_string());
         }
 
         Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,9 @@
 
 #[cfg(feature = "full")]
 use crate::app::App;
+use crate::app::InnerApp;
 use crate::app::Nom;
+use crate::app_client;
 #[cfg(feature = "full")]
 use crate::bitcoin::adapter::Adapter;
 #[cfg(feature = "full")]
@@ -10,7 +12,6 @@ use crate::bitcoin::header_queue::Config as HeaderQueueConfig;
 #[cfg(feature = "full")]
 use crate::bitcoin::signer::Signer;
 use crate::error::{Error, Result};
-use crate::{app::InnerApp, app_client_testnet};
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::{self, rand, SecretKey};
 #[cfg(feature = "full")]
@@ -52,6 +53,8 @@ use std::process::{Child, Command, Stdio};
 use std::str::FromStr;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const DEFAULT_RPC: &str = "http://localhost:26657";
 
 pub fn retry<F, T, E>(f: F, max_retries: u32) -> std::result::Result<T, E>
 where
@@ -235,7 +238,7 @@ pub async fn declare_validator(home: &Path, wallet: DerivedKey) -> Result<()> {
         min_self_delegation: 0.into(),
     };
 
-    app_client_testnet()
+    app_client(DEFAULT_RPC)
         .with_wallet(wallet)
         .call(
             move |app| build_call!(app.accounts.take_as_funding((100000 + MIN_FEE).into())),
@@ -250,7 +253,10 @@ pub async fn declare_validator(home: &Path, wallet: DerivedKey) -> Result<()> {
 pub async fn poll_for_blocks() {
     info!("Scanning for blocks...");
     loop {
-        match app_client_testnet().query(|app| app.app_noop_query()).await {
+        match app_client(DEFAULT_RPC)
+            .query(|app| app.app_noop_query())
+            .await
+        {
             Ok(_) => {
                 break;
             }
@@ -264,7 +270,7 @@ pub async fn poll_for_blocks() {
 pub async fn poll_for_signatory_key() {
     info!("Scanning for signatory key...");
     loop {
-        match app_client_testnet()
+        match app_client(DEFAULT_RPC)
             .query(|app| Ok(app.bitcoin.checkpoints.active_sigset()?))
             .await
         {
@@ -276,13 +282,13 @@ pub async fn poll_for_signatory_key() {
 
 pub async fn poll_for_completed_checkpoint(num_checkpoints: u32) {
     info!("Scanning for signed checkpoints...");
-    let mut checkpoint_len = app_client_testnet()
+    let mut checkpoint_len = app_client(DEFAULT_RPC)
         .query(|app| Ok(app.bitcoin.checkpoints.completed()?.len()))
         .await
         .unwrap();
 
     while checkpoint_len < num_checkpoints as usize {
-        checkpoint_len = app_client_testnet()
+        checkpoint_len = app_client(DEFAULT_RPC)
             .query(|app| Ok(app.bitcoin.checkpoints.completed()?.len()))
             .await
             .unwrap();
@@ -293,7 +299,7 @@ pub async fn poll_for_completed_checkpoint(num_checkpoints: u32) {
 pub async fn poll_for_bitcoin_header(height: u32) -> Result<()> {
     info!("Scanning for bitcoin header {}...", height);
     loop {
-        let current_height = app_client_testnet()
+        let current_height = app_client(DEFAULT_RPC)
             .query(|app| Ok(app.bitcoin.headers.height()?))
             .await?;
         if current_height >= height {

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -197,7 +197,7 @@ async fn bitcoin_test() {
     let checkpoints = relayer.start_checkpoint_relay();
 
     #[cfg(feature = "emergency-disbursal")]
-    let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind));
+    let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind), rpc_addr.clone());
     #[cfg(feature = "emergency-disbursal")]
     let disbursal = relayer.start_emergency_disbursal_transaction_relay();
     #[cfg(not(feature = "emergency-disbursal"))]


### PR DESCRIPTION
Support `--node` in CLI commands, defaulting to `localhost:26657`. A future change should also make the default check the Tendermint config to support nonstandard ports automatically.