### PR TITLE
Default disbursal path removal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "nomic"
 version = "6.0.2"
-authors = [ "The Nomic Team <hello@nomic.io>" ]
+authors = ["The Nomic Team <hello@nomic.io>"]
 edition = "2021"
 default-run = "nomic"
 
 [dependencies]
 bitcoin = { version = "0.29.2", features = ["serde", "rand"] }
 bitcoind = { version = "0.27.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "860052c382b01fa5d5c4b4d954da4aa129adacb9", features = ["merk-verify", "compat"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "860052c382b01fa5d5c4b4d954da4aa129adacb9", features = [
+    "merk-verify",
+    "compat",
+] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }
@@ -21,7 +24,9 @@ csv = { version = "1.1.6", optional = true }
 bech32 = { version = "0.9.1" }
 futures = "0.3.21"
 toml_edit = "0.13.4"
-tendermint-rpc = { version = "=0.30.0", features = ["http-client"], optional = true}
+tendermint-rpc = { version = "=0.30.0", features = [
+    "http-client",
+], optional = true }
 bitcoincore-rpc-async = { package = "bitcoincore-rpc-async2", version = "4.0.1", optional = true }
 bitcoin-script = "0.1.1"
 warp = { version = "0.3.2", optional = true }
@@ -38,7 +43,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 split-iter = "0.1.0"
 chrono = "0.4.19"
 tempfile = "3"
-home = {version = "0.5.5", optional = true }
+home = { version = "0.5.5", optional = true }
 semver = "1.0.18"
 
 [dev-dependencies]
@@ -59,9 +64,24 @@ semver = "1.0.18"
 
 [features]
 default = ["full", "feat-ibc"]
-full = ["bitcoind", "bitcoincore-rpc-async", "clap", "tokio", "orga/merk-full", "orga/abci", "orga/state-sync", "csv", "warp", "rand", "reqwest", "tendermint-rpc", "home"]
+full = [
+    "bitcoind",
+    "bitcoincore-rpc-async",
+    "clap",
+    "tokio",
+    "orga/merk-full",
+    "orga/abci",
+    "orga/state-sync",
+    "csv",
+    "warp",
+    "rand",
+    "reqwest",
+    "tendermint-rpc",
+    "home",
+]
 feat-ibc = ["orga/feat-ibc"]
 testnet = []
+devnet = []
 emergency-disbursal = []
 legacy-bin = []
 

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1333,6 +1333,17 @@ impl CheckpointQueue {
 
 #[cfg(test)]
 mod test {
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use bitcoin::{
+        util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey},
+        OutPoint, PubkeyHash, Script, Txid,
+    };
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use rand::Rng;
+
+    #[cfg(all(feature = "full", not(feature = "emergency-disbursal")))]
+    use crate::bitcoin::{signatory::Signatory, threshold_sig::Share};
+
     use super::*;
 
     fn push_bitcoin_tx_output(tx: &mut BitcoinTx, value: u64) {

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -685,7 +685,10 @@ impl<'a> BuildingCheckpointMut<'a> {
 
         let mut disbursal_batch = self.batches.get_mut(BatchType::Disbursal as u64)?.unwrap();
         disbursal_batch.retain_unordered(|mut tx| {
-            let mut input = tx.input.get_mut(0)?.unwrap();
+            let mut input = match tx.input.get_mut(0)? {
+                Some(input) => input,
+                None => return Ok(false),
+            };
             input.amount -= intermediate_tx_fee / intermediate_tx_len;
             for (i, output) in intermediate_tx_outputs.iter() {
                 if output == &(input.amount) {

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -730,35 +730,23 @@ impl<'a> BuildingCheckpointMut<'a> {
             let lock_time =
                 time.seconds as u32 + bitcoin_config.emergency_disbursal_lock_time_interval;
 
-            let outputs: Vec<_> = nbtc_accounts
-                .iter()?
-                .map(|entry| {
-                    let (address, coins) = entry?;
-                    use bitcoin::hashes::hex::ToHex;
-                    use std::str::FromStr;
-                    let hash =
-                        bitcoin::hashes::hash160::Hash::from_str(address.bytes().to_hex().as_str())
-                            .map_err(|err| Error::BitcoinPubkeyHash(err.to_string()))?;
-                    let pubkey_hash = bitcoin::PubkeyHash::from(hash);
-                    let dest_script = match recovery_scripts.get(*address)? {
-                        Some(script) => script.clone(),
-                        None => Adapter::new(bitcoin::Script::new_p2pkh(&pubkey_hash)),
-                    };
-
+            let mut outputs = Vec::new();
+            for entry in nbtc_accounts.iter()? {
+                let (address, coins) = entry?;
+                if let Some(dest_script) = recovery_scripts.get(*address)? {
                     let tx_out = bitcoin::TxOut {
                         value: u64::from(coins.amount) / 1_000_000,
-                        script_pubkey: dest_script.into_inner(),
+                        script_pubkey: dest_script.clone().into_inner(),
                     };
 
-                    Ok::<_, crate::error::Error>(tx_out)
-                })
-                .chain(external_outputs)
-                .collect();
+                    outputs.push(Ok(tx_out));
+                }
+            }
 
             let mut final_txs = vec![BitcoinTx::with_lock_time(lock_time)];
 
             let num_outputs = outputs.len();
-            for (i, output) in outputs.into_iter().enumerate() {
+            for (i, output) in outputs.into_iter().chain(external_outputs).enumerate() {
                 let output = output?;
 
                 if output.value < bitcoin_config.emergency_disbursal_min_tx_amt {

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1333,14 +1333,6 @@ impl CheckpointQueue {
 
 #[cfg(test)]
 mod test {
-    use bitcoin::{
-        util::bip32::{ChildNumber, ExtendedPrivKey, ExtendedPubKey},
-        OutPoint, PubkeyHash, Script, Txid,
-    };
-    use rand::Rng;
-
-    use crate::bitcoin::{signatory::Signatory, threshold_sig::Share};
-
     use super::*;
 
     fn push_bitcoin_tx_output(tx: &mut BitcoinTx, value: u64) {

--- a/src/bitcoin/signer.rs
+++ b/src/bitcoin/signer.rs
@@ -39,7 +39,13 @@ impl<W: Wallet> Signer<W> {
         } else {
             info!("Generating signatory key at {}", path.display());
             let seed: [u8; 32] = rand::thread_rng().gen();
-            let xpriv = ExtendedPrivKey::new_master(bitcoin::Network::Bitcoin, seed.as_slice())?;
+
+            let network = if super::NETWORK == bitcoin::Network::Regtest {
+                bitcoin::Network::Testnet
+            } else {
+                super::NETWORK
+            };
+            let xpriv = ExtendedPrivKey::new_master(network, seed.as_slice())?;
 
             fs::write(path, xpriv.to_string().as_bytes())?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -363,8 +363,6 @@ pub fn setup_test_app(
     block_data: &BitcoinBlockData,
     num_accounts: u16,
 ) -> Vec<NomicTestWallet> {
-    use orga::client::Wallet;
-
     let mut app = ABCIPlugin::<App>::default();
     let mut store = Store::new(BackingStore::Merk(Shared::new(MerkStore::new(
         home.join("merk"),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -358,7 +358,11 @@ impl NomicTestWallet {
 }
 
 #[cfg(feature = "full")]
-pub fn setup_test_app(home: &Path, block_data: &BitcoinBlockData) -> Vec<NomicTestWallet> {
+pub fn setup_test_app(
+    home: &Path,
+    block_data: &BitcoinBlockData,
+    num_accounts: u16,
+) -> Vec<NomicTestWallet> {
     use orga::client::Wallet;
 
     let mut app = ABCIPlugin::<App>::default();
@@ -400,7 +404,7 @@ pub fn setup_test_app(home: &Path, block_data: &BitcoinBlockData) -> Vec<NomicTe
             .deposit(address, Coin::mint(1000000000))
             .unwrap();
 
-        let keys: Vec<NomicTestWallet> = (0..10)
+        let keys: Vec<NomicTestWallet> = (0..num_accounts)
             .map(|_| {
                 let privkey = SecretKey::new(&mut rand::thread_rng());
                 let address = address_from_privkey(&privkey);

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -394,7 +394,7 @@ async fn bitcoin_test() {
         let expected_account_balances: Vec<u64> = vec![799990201, 0];
         assert_eq!(funded_account_balances, expected_account_balances);
 
-        for (i, account) in funded_accounts[0..=1].iter().enumerate() {
+        for (i, account) in funded_accounts[0..1].iter().enumerate() {
             let dump_address = wallet.get_new_address(None, None).unwrap();
             let disbursal_txs = app_client_testnet()
                 .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs()?))

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -9,7 +9,6 @@ use bitcoind::{BitcoinD, Conf};
 use log::info;
 use nomic::app::DepositCommitment;
 use nomic::app::{InnerApp, Nom};
-use nomic::app_client_testnet;
 use nomic::bitcoin::adapter::Adapter;
 use nomic::bitcoin::relayer::DepositAddress;
 use nomic::bitcoin::relayer::Relayer;
@@ -39,8 +38,7 @@ use tempfile::tempdir;
 
 static INIT: Once = Once::new();
 
-fn app_client(
-) -> AppClient<app::InnerApp, app::InnerApp, orga::tendermint::client::HttpClient, app::Nom, Unsigned>
+fn app_client() -> AppClient<InnerApp, InnerApp, orga::tendermint::client::HttpClient, Nom, Unsigned>
 {
     nomic::app_client("http://localhost:26657")
 }
@@ -99,7 +97,7 @@ pub async fn broadcast_deposit_addr(
 async fn set_recovery_address(nomic_account: NomicTestWallet) -> Result<()> {
     info!("Setting recovery address...");
 
-    app_client_testnet()
+    app_client()
         .with_wallet(nomic_account.wallet)
         .call(
             move |app| build_call!(app.accounts.take_as_funding((MIN_FEE).into())),
@@ -153,7 +151,7 @@ async fn withdraw_bitcoin(
 ) -> Result<()> {
     let dest_script = nomic::bitcoin::adapter::Adapter::new(dest_address.script_pubkey());
     let usats = amount.to_sat() * 1_000_000;
-    app_client_testnet()
+    app_client()
         .with_wallet(nomic_account.wallet.clone())
         .call(
             move |app| build_call!(app.withdraw_nbtc(dest_script, Amount::from(usats))),
@@ -164,7 +162,7 @@ async fn withdraw_bitcoin(
 }
 
 async fn get_signatory_script() -> Result<Script> {
-    Ok(app_client_testnet()
+    Ok(app_client()
         .query(|app: InnerApp| {
             let tx = app.bitcoin.checkpoints.emergency_disbursal_txs()?;
             Ok(tx[0].output[1].script_pubkey.clone())

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -164,7 +164,7 @@ async fn withdraw_bitcoin(
 async fn get_signatory_script() -> Result<Script> {
     Ok(app_client()
         .query(|app: InnerApp| {
-            let tx = app.bitcoin.checkpoints.emergency_disbursal_txs()?;
+            let tx = app.bitcoin.checkpoints.emergency_disbursal_txs(1_000)?;
             Ok(tx[0].output[1].script_pubkey.clone())
         })
         .await?)

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -139,6 +139,15 @@ async fn withdraw_bitcoin(
     Ok(())
 }
 
+async fn get_signatory_script() -> Result<Script> {
+    Ok(app_client_testnet()
+        .query(|app: InnerApp| {
+            let tx = app.bitcoin.checkpoints.emergency_disbursal_txs()?;
+            Ok(tx[0].output[1].script_pubkey.clone())
+        })
+        .await?)
+}
+
 fn client_provider() -> AppClient<InnerApp, InnerApp, HttpClient, Nom, DerivedKey> {
     let val_priv_key = load_privkey().unwrap();
     let wallet = DerivedKey::from_secret_key(val_priv_key);

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -87,6 +87,24 @@ pub async fn broadcast_deposit_addr(
     }
 }
 
+async fn set_recovery_address(nomic_account: NomicTestWallet) -> Result<()> {
+    info!("Setting recovery address...");
+
+    app_client_testnet()
+        .with_wallet(nomic_account.wallet)
+        .call(
+            move |app| build_call!(app.accounts.take_as_funding((MIN_FEE).into())),
+            move |app| {
+                build_call!(app
+                    .bitcoin
+                    .set_recovery_script(Adapter::new(nomic_account.script.clone())))
+            },
+        )
+        .await?;
+    info!("Validator declared");
+    Ok(())
+}
+
 async fn deposit_bitcoin(
     address: &Address,
     btc: bitcoin::Amount,

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -195,7 +195,7 @@ async fn bitcoin_test() {
 
     std::env::set_var("NOMIC_HOME_DIR", &path);
 
-    let funded_accounts = setup_test_app(&path, &block_data);
+    let funded_accounts = setup_test_app(&path, &block_data, 2);
 
     std::thread::spawn(move || {
         info!("Starting Nomic node...");
@@ -391,7 +391,7 @@ async fn bitcoin_test() {
             })
             .collect();
 
-        let expected_account_balances: Vec<u64> = vec![799990201, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let expected_account_balances: Vec<u64> = vec![799990201, 0];
         assert_eq!(funded_account_balances, expected_account_balances);
 
         for (i, account) in funded_accounts[0..=1].iter().enumerate() {

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -368,7 +368,6 @@ async fn bitcoin_test() {
 
         let mut signatory_balance = 0;
         for tx in txs {
-            info!("tx: {:?}", tx);
             for output in tx.output.iter() {
                 if output.script_pubkey == signatory_script {
                     signatory_balance = output.value;

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -26,7 +26,6 @@ use orga::coins::{Address, Amount};
 use orga::encoding::Encode;
 use orga::macros::build_call;
 use orga::plugins::{load_privkey, MIN_FEE};
-use orga::query::MethodQuery;
 use orga::tendermint::client::HttpClient;
 use reqwest::StatusCode;
 use serial_test::serial;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 // use crate::web_client::WebClient;
 use js_sys::{Array, Uint8Array};
 use nomic::app::{App, DepositCommitment, InnerApp, Nom};
-use nomic::bitcoin::Nbtc;
+use nomic::bitcoin::{Nbtc, NETWORK as BITCOIN_NETWORK};
 use nomic::orga::client::wallet::Unsigned;
 use nomic::orga::client::AppClient;
 use nomic::orga::coins::Address;
@@ -25,8 +25,6 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_client::WebClient;
 use web_sys::{Request, RequestInit, RequestMode, Response};
-
-const BITCOIN_NETWORK: bitcoin::Network = ::bitcoin::Network::Testnet;
 
 #[wasm_bindgen(start)]
 pub fn main() -> std::result::Result<(), JsValue> {
@@ -433,7 +431,7 @@ pub async fn gen_deposit_addr(dest_addr: String) -> Result<DepositAddress, JsErr
     )?;
     // TODO: get network from somewhere
     // TODO: make test/mainnet option configurable
-    let btc_addr = bitcoin::Address::from_script(&script, bitcoin::Network::Testnet)?;
+    let btc_addr = bitcoin::Address::from_script(&script, BITCOIN_NETWORK)?;
 
     Ok(DepositAddress {
         address: btc_addr.to_string(),


### PR DESCRIPTION
This PR removes the default emergency disbursal redeem path. A recovery address is now required to be included in the emergency disbursal. All funds not protected by a recovery address will be paid back to the signatory set of the Nomic checkpoint that generated the emergency disbursal and will be recoverable by users after further validator coordination.