### PR TITLE
Limit number of checkpoints in queries

### DIFF
--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1066,13 +1066,14 @@ impl CheckpointQueue {
     }
 
     #[query]
-    pub fn completed(&self) -> Result<Vec<CompletedCheckpoint<'_>>> {
+    pub fn completed(&self, limit: u32) -> Result<Vec<CompletedCheckpoint<'_>>> {
         // TODO: return iterator
         // TODO: use Deque iterator
 
         let mut out = vec![];
 
-        for i in 0..self.queue.len() {
+        let start = self.queue.len().saturating_sub(limit as u64);
+        for i in start..self.queue.len() {
             let checkpoint = self.queue.get(i)?.unwrap();
 
             if !matches!(checkpoint.status, CheckpointStatus::Complete) {
@@ -1086,7 +1087,7 @@ impl CheckpointQueue {
     }
 
     #[query]
-    pub fn last_completed_tx(&self) -> Result<Adapter<bitcoin::Transaction>> {
+    pub fn last_completed(&self) -> Result<Ref<Checkpoint>> {
         let index = if self.signing()?.is_some() {
             self.index.checked_sub(2)
         } else {
@@ -1094,28 +1095,36 @@ impl CheckpointQueue {
         }
         .ok_or_else(|| Error::Orga(OrgaError::App("No completed checkpoints yet".to_string())))?;
 
-        let bitcoin_tx = self.get(index)?.checkpoint_tx()?;
+        self.get(index)
+    }
+
+    #[query]
+    pub fn last_completed_tx(&self) -> Result<Adapter<bitcoin::Transaction>> {
+        let bitcoin_tx = self.last_completed()?.checkpoint_tx()?;
         Ok(Adapter::new(bitcoin_tx))
     }
 
     #[query]
-    pub fn completed_txs(&self) -> Result<Vec<Adapter<bitcoin::Transaction>>> {
-        self.completed()?
+    pub fn completed_txs(&self, limit: u32) -> Result<Vec<Adapter<bitcoin::Transaction>>> {
+        self.completed(limit)?
             .into_iter()
             .map(|c| Ok(Adapter::new(c.checkpoint_tx()?)))
             .collect()
     }
 
     #[query]
-    pub fn emergency_disbursal_txs(&self) -> Result<Vec<Adapter<bitcoin::Transaction>>> {
+    pub fn emergency_disbursal_txs(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<Adapter<bitcoin::Transaction>>> {
         #[cfg(not(feature = "emergency-disbursal"))]
-        unimplemented!();
+        unimplemented!("{}", limit);
 
         #[cfg(feature = "emergency-disbursal")]
         {
             let mut vec = vec![];
 
-            if let Some(completed) = self.completed()?.last() {
+            if let Some(completed) = self.completed(limit)?.last() {
                 let intermediate_tx_batch = completed
                     .batches
                     .get(BatchType::IntermediateTx as u64)?

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -506,11 +506,7 @@ impl Bitcoin {
 
     #[query]
     pub fn value_locked(&self) -> Result<u64> {
-        let completed = self.checkpoints.completed()?;
-        if completed.is_empty() {
-            return Ok(0);
-        }
-        let last_completed = completed.iter().last().unwrap();
+        let last_completed = self.checkpoints.last_completed()?;
         Ok(last_completed.reserve_output()?.unwrap().value)
     }
 
@@ -530,7 +526,8 @@ impl Bitcoin {
         }
         let now = signing.create_time().max(now);
 
-        let completed = self.checkpoints.completed()?;
+        // TODO: is this a good completed query limit?
+        let completed = self.checkpoints.completed(1_000)?;
         if completed.is_empty() {
             return Ok(ChangeRates::default());
         }

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -298,7 +298,7 @@ impl Relayer {
         let mut relayed = HashSet::new();
         loop {
             let disbursal_txs = app_client(&self.app_client_addr)
-                .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs()?))
+                .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs(1_000)?))
                 .await?;
 
             for tx in disbursal_txs.iter() {
@@ -360,7 +360,7 @@ impl Relayer {
 
         loop {
             let txs = app_client(&self.app_client_addr)
-                .query(|app| Ok(app.bitcoin.checkpoints.completed_txs()?))
+                .query(|app| Ok(app.bitcoin.checkpoints.completed_txs(1_000)?))
                 .await?;
             for tx in txs {
                 if relayed.contains(&tx.txid()) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -283,13 +283,13 @@ pub async fn poll_for_signatory_key() {
 pub async fn poll_for_completed_checkpoint(num_checkpoints: u32) {
     info!("Scanning for signed checkpoints...");
     let mut checkpoint_len = app_client(DEFAULT_RPC)
-        .query(|app| Ok(app.bitcoin.checkpoints.completed()?.len()))
+        .query(|app| Ok(app.bitcoin.checkpoints.completed(1_000)?.len()))
         .await
         .unwrap();
 
     while checkpoint_len < num_checkpoints as usize {
         checkpoint_len = app_client(DEFAULT_RPC)
-            .query(|app| Ok(app.bitcoin.checkpoints.completed()?.len()))
+            .query(|app| Ok(app.bitcoin.checkpoints.completed(1_000)?.len()))
             .await
             .unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -359,7 +359,7 @@ async fn bitcoin_test() {
         for (i, account) in funded_accounts[0..=1].iter().enumerate() {
             let dump_address = wallet.get_new_address(None, None).unwrap();
             let disbursal_txs = app_client()
-                .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs()?))
+                .query(|app| Ok(app.bitcoin.checkpoints.emergency_disbursal_txs(1_000)?))
                 .await
                 .unwrap();
 


### PR DESCRIPTION
This PR fixes the relayer getting stuck on chains with sufficiently large checkpoint queues (the proofs were previously exceeding Tendermint's maximum query size).