### PR TITLE
Prune fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "5.2.0"
+version = "5.2.1"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1103,7 +1103,11 @@ impl CheckpointQueue {
     }
 
     pub fn prune(&mut self) -> Result<()> {
-        let latest = self.building()?.create_time();
+        if self.len()? <= 3 {
+            return Ok(());
+        }
+
+        let latest = self.get(self.index - 2)?.create_time();
 
         while let Some(oldest) = self.queue.front()? {
             if latest - oldest.create_time() <= self.config.max_age {


### PR DESCRIPTION
This PR is a hotfix for the "Index out of bounds" error currently breaking testnet in the `BeginBlock` implementation at height 7246085. The error is caused by Bitcoin checkpoint pruning removing all but the most recent checkpoint, then immediately trying to read from the second-to-last checkpoint which no longer exists.

Since the checkpoints have not been stuck for the entire pruning period in the past, and since nodes encountering the error have not committed changes for block 7246084, this change is not a typical breaking change and does not have to go through the full upgrade mechanism. Node operators should all update to this version so that the network can progress.