### PR TITLE
Process NBTC deposits and transfers after including checkpoint is signed

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -952,6 +952,18 @@ impl Dest {
         let bytes = self.encode()?;
         Ok(base64::encode(bytes))
     }
+
+    pub fn to_output_script(
+        &self,
+        recovery_scripts: &orga::collections::Map<Address, Adapter<Script>>,
+    ) -> Result<Option<Script>> {
+        match self {
+            Dest::Address(addr) => Ok(recovery_scripts
+                .get(addr.clone())?
+                .map(|script| script.clone().into_inner())),
+            _ => Ok(None),
+        }
+    }
 }
 
 impl State for Dest {

--- a/src/app.rs
+++ b/src/app.rs
@@ -959,7 +959,7 @@ impl Dest {
     ) -> Result<Option<Script>> {
         match self {
             Dest::Address(addr) => Ok(recovery_scripts
-                .get(addr.clone())?
+                .get(*addr)?
                 .map(|script| script.clone().into_inner())),
             _ => Ok(None),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,12 +8,13 @@ use crate::bitcoin::adapter::Adapter;
 use crate::bitcoin::{Bitcoin, Nbtc};
 use crate::incentives::Incentives;
 use bitcoin::util::merkleblock::PartialMerkleTree;
-use bitcoin::Transaction;
+use bitcoin::{Script, Transaction, TxOut};
 use orga::coins::{
     Accounts, Address, Amount, Coin, Faucet, FaucetOptions, Give, Staking, Symbol, Take,
 };
 use orga::context::GetContext;
 use orga::cosmrs::bank::MsgSend;
+use orga::describe::{Describe, Descriptor};
 use orga::encoding::{Decode, Encode};
 use std::time::Duration;
 
@@ -213,22 +214,25 @@ impl InnerApp {
         btc_proof: Adapter<PartialMerkleTree>,
         btc_vout: u32,
         sigset_index: u32,
-        dest: DepositCommitment,
+        dest: Dest,
     ) -> Result<()> {
-        let nbtc = self.bitcoin.relay_deposit(
+        Ok(self.bitcoin.relay_deposit(
             btc_tx,
             btc_height,
             btc_proof,
             btc_vout,
             sigset_index,
-            dest.commitment_bytes()?.as_slice(),
-        )?;
+            dest,
+        )?)
+    }
+
+    pub fn credit_deposit(&mut self, dest: Dest, nbtc: Amount) -> Result<()> {
         match dest {
-            DepositCommitment::Address(addr) => self.bitcoin.accounts.deposit(addr, nbtc.into()),
+            Dest::Address(addr) => self.bitcoin.accounts.deposit(addr, nbtc.into()),
             #[cfg(not(feature = "testnet"))]
-            DepositCommitment::Ibc(dest) => Err(Error::Unknown),
+            Dest::Ibc(dest) => Err(Error::Unknown),
             #[cfg(feature = "testnet")]
-            DepositCommitment::Ibc(dest) => {
+            Dest::Ibc(dest) => {
                 use orga::ibc::ibc_rs::applications::transfer::msgs::transfer::MsgTransfer;
                 let fee = ibc_fee(nbtc)?;
                 let nbtc_after_fee = (nbtc - fee).result()?;
@@ -379,6 +383,10 @@ mod abci {
             let ip_reward = self.incentive_pool_rewards.mint()?;
             self.incentive_pool.give(ip_reward)?;
 
+            let pending_nbtc_transfers = self.bitcoin.take_pending()?;
+            for (dest, coins) in pending_nbtc_transfers {
+                self.credit_deposit(dest, coins.amount)?;
+            }
             let external_outputs: Vec<crate::error::Result<bitcoin::TxOut>> = vec![]; // TODO: remote chain disbursal
             let offline_signers = self
                 .bitcoin
@@ -904,26 +912,28 @@ pub struct MsgIbcTransfer {
     pub timeout_timestamp: String,
 }
 
-#[derive(Encode, Decode, Debug, Clone)]
-pub enum DepositCommitment {
+#[derive(Encode, Decode, Debug, Clone, Serialize)]
+pub enum Dest {
     Address(Address),
-    Ibc(IbcDepositCommitment),
+    Ibc(IbcDest),
 }
 
 use orga::ibc::{IbcMessage, PortChannel, RawIbcTx};
 
-#[derive(Clone, Debug, Encode, Decode)]
-pub struct IbcDepositCommitment {
+#[derive(Clone, Debug, Encode, Decode, Serialize)]
+pub struct IbcDest {
     pub source: PortChannel,
+    #[serde(skip)]
     pub receiver: EdAdapter<IbcSigner>,
+    #[serde(skip)]
     pub sender: EdAdapter<IbcSigner>,
     pub timeout_timestamp: u64,
 }
 
-impl DepositCommitment {
+impl Dest {
     pub fn commitment_bytes(&self) -> Result<Vec<u8>> {
         use sha2::{Digest, Sha256};
-        use DepositCommitment::*;
+        use Dest::*;
         let bytes = match self {
             Address(addr) => addr.bytes().into(),
             Ibc(dest) => Sha256::digest(dest.encode()?).to_vec(),
@@ -941,6 +951,43 @@ impl DepositCommitment {
     pub fn to_base64(&self) -> Result<String> {
         let bytes = self.encode()?;
         Ok(base64::encode(bytes))
+    }
+}
+
+impl State for Dest {
+    fn attach(&mut self, store: Store) -> Result<()> {
+        Ok(())
+    }
+
+    fn load(_store: Store, bytes: &mut &[u8]) -> Result<Self> {
+        Ok(Self::decode(bytes)?)
+    }
+
+    fn flush<W: std::io::Write>(self, out: &mut W) -> Result<()> {
+        self.encode_into(out)?;
+        Ok(())
+    }
+}
+
+impl Query for Dest {
+    type Query = ();
+
+    fn query(&self, query: Self::Query) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Migrate for Dest {
+    fn migrate(src: Store, _dest: Store, bytes: &mut &[u8]) -> Result<Self> {
+        Self::load(src, bytes)
+    }
+}
+
+impl Describe for Dest {
+    fn describe() -> Descriptor {
+        ::orga::describe::Builder::new::<Self>()
+            .meta::<()>()
+            .build()
     }
 }
 

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -82,8 +82,8 @@ pub enum Command {
     #[cfg(feature = "testnet")]
     InterchainDeposit(InterchainDepositCmd),
     Withdraw(WithdrawCmd),
-    #[cfg(feature = "testnet")]
-    IbcDepositNbtc(IbcDepositNbtcCmd),
+    // #[cfg(feature = "testnet")]
+    // IbcDepositNbtc(IbcDepositNbtcCmd),
     #[cfg(feature = "testnet")]
     IbcWithdrawNbtc(IbcWithdrawNbtcCmd),
     #[cfg(feature = "testnet")]
@@ -135,8 +135,8 @@ impl Command {
                 #[cfg(feature = "testnet")]
                 InterchainDeposit(cmd) => cmd.run().await,
                 Withdraw(cmd) => cmd.run().await,
-                #[cfg(feature = "testnet")]
-                IbcDepositNbtc(cmd) => cmd.run().await,
+                // #[cfg(feature = "testnet")]
+                // IbcDepositNbtc(cmd) => cmd.run().await,
                 #[cfg(feature = "testnet")]
                 IbcWithdrawNbtc(cmd) => cmd.run().await,
                 #[cfg(feature = "testnet")]
@@ -1344,30 +1344,30 @@ impl WithdrawCmd {
     }
 }
 
-#[cfg(feature = "testnet")]
-#[derive(Parser, Debug)]
-pub struct IbcDepositNbtcCmd {
-    to: Address,
-    amount: u64,
+// #[cfg(feature = "testnet")]
+// #[derive(Parser, Debug)]
+// pub struct IbcTransferNbtcCmd {
+//     to: Address,
+//     amount: u64,
 
-    #[clap(flatten)]
-    config: nomic::network::Config,
-}
+//     #[clap(flatten)]
+//     config: nomic::network::Config,
+// }
 
-#[cfg(feature = "testnet")]
-impl IbcDepositNbtcCmd {
-    async fn run(&self) -> Result<()> {
-        Ok(self
-            .config
-            .client()
-            .with_wallet(wallet())
-            .call(
-                |app| build_call!(app.ibc_deposit_nbtc(self.to, self.amount.into())),
-                |app| build_call!(app.app_noop()),
-            )
-            .await?)
-    }
-}
+// #[cfg(feature = "testnet")]
+// impl IbcTransferNbtcCmd {
+//     async fn run(&self) -> Result<()> {
+//         Ok(self
+//             .config
+//             .client()
+//             .with_wallet(wallet())
+//             .call(
+//                 |app| build_call!(app.ibc_transfer_nbtc(self.to, self.amount.into())),
+//                 |app| build_call!(app.app_noop()),
+//             )
+//             .await?)
+//     }
+// }
 
 #[cfg(feature = "testnet")]
 #[derive(Parser, Debug)]

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -6,7 +6,7 @@
 
 use bitcoind::bitcoincore_rpc::{Auth, Client as BtcClient};
 use clap::Parser;
-use nomic::app::DepositCommitment;
+use nomic::app::Dest;
 use nomic::app::InnerApp;
 use nomic::app::Nom;
 use nomic::bitcoin::{relayer::Relayer, signer::Signer};
@@ -1239,7 +1239,7 @@ impl SetSignatoryKeyCmd {
 }
 
 async fn deposit(
-    dest: DepositCommitment,
+    dest: Dest,
     client: AppClient<InnerApp, InnerApp, HttpClient, Nom, orga::client::wallet::Unsigned>,
 ) -> Result<()> {
     let sigset = client
@@ -1283,7 +1283,7 @@ impl DepositCmd {
     async fn run(&self) -> Result<()> {
         let dest_addr = self.address.unwrap_or_else(my_address);
 
-        deposit(DepositCommitment::Address(dest_addr), self.config.client()).await
+        deposit(Dest::Address(dest_addr), self.config.client()).await
     }
 }
 
@@ -1304,7 +1304,7 @@ impl InterchainDepositCmd {
         todo!()
         // use orga::ibc::encoding::Adapter;
         // let now_ns = now_seconds() as u64 * 1_000_000_000;
-        // let dest = DepositCommitment::Ibc(nomic::app::IbcDepositCommitment {
+        // let dest = Dest::Ibc(nomic::app::IbcDest {
         //     receiver: Adapter::new(self.receiver.parse().unwrap()),
         //     sender: Adapter::new(my_address().to_string().parse().unwrap()),
         //     source_channel: Adapter::new(self.channel.parse().unwrap()),

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use self::checkpoint::Input;
+use crate::app::Dest;
 use crate::bitcoin::checkpoint::BatchType;
 use crate::error::{Error, Result};
 use ::bitcoin::util::bip32::ChildNumber;
@@ -326,8 +327,8 @@ impl Bitcoin {
         btc_proof: Adapter<PartialMerkleTree>,
         btc_vout: u32,
         sigset_index: u32,
-        dest: &[u8],
-    ) -> Result<Amount> {
+        dest: super::app::Dest,
+    ) -> Result<()> {
         exempt_from_fee()?;
 
         let btc_header = self
@@ -381,12 +382,25 @@ impl Bitcoin {
             return Err(OrgaError::App("Deposit timeout has expired".to_string()))?;
         }
 
-        let expected_script = sigset.output_script(dest)?;
+        let dest_bytes = dest.commitment_bytes()?;
+        let expected_script = sigset.output_script(&dest_bytes)?;
         if output.script_pubkey != expected_script {
             return Err(OrgaError::App(
                 "Output script does not match signature set".to_string(),
             ))?;
         }
+
+        let prevout = bitcoin::OutPoint {
+            txid: btc_tx.txid(),
+            vout: btc_vout,
+        };
+        let input = Input::new(prevout, &sigset, &dest_bytes, output.value)?;
+        let input_size = input.est_vsize();
+
+        let fee = input_size * self.checkpoints.config().fee_rate;
+        let value = output.value.checked_sub(fee).ok_or_else(|| {
+            OrgaError::App("Deposit amount is too small to pay its spending fee".to_string())
+        })? * self.config.units_per_sat;
 
         let outpoint = (btc_tx.txid().into_inner(), btc_vout);
         if self.processed_outpoints.contains(outpoint)? {
@@ -397,34 +411,24 @@ impl Bitcoin {
         self.processed_outpoints
             .insert(outpoint, sigset.deposit_timeout())?;
 
-        let prevout = bitcoin::OutPoint {
-            txid: btc_tx.txid(),
-            vout: btc_vout,
-        };
-
-        // TODO: don't credit account until we're done signing including tx;
         let mut building_mut = self.checkpoints.building_mut()?;
         let mut building_checkpoint_batch = building_mut
             .batches
             .get_mut(BatchType::Checkpoint as u64)?
             .unwrap();
-
         let mut checkpoint_tx = building_checkpoint_batch.get_mut(0)?.unwrap();
-        let input = Input::new(prevout, &sigset, dest, output.value)?;
-        let input_size = input.est_vsize();
         checkpoint_tx.input.push_back(input)?;
-
-        let fee = input_size * self.checkpoints.config().fee_rate;
-
-        let value = output.value.checked_sub(fee).ok_or_else(|| {
-            OrgaError::App("Deposit amount is too small to pay its spending fee".to_string())
-        })? * self.config.units_per_sat;
 
         let mut minted_nbtc = Nbtc::mint(value);
         let deposit_fee = minted_nbtc.take(calc_deposit_fee(value))?;
         self.reward_pool.give(deposit_fee)?;
 
-        Ok(minted_nbtc.amount)
+        self.checkpoints
+            .building_mut()?
+            .pending
+            .insert(dest, minted_nbtc)?;
+
+        Ok(())
     }
 
     pub fn withdraw(&mut self, script_pubkey: Adapter<Script>, amount: Amount) -> Result<()> {
@@ -671,6 +675,27 @@ impl Bitcoin {
 
         Ok(offline_signers)
     }
+
+    pub fn take_pending(&mut self) -> Result<Vec<(Dest, Coin<Nbtc>)>> {
+        if let Err(Error::Orga(OrgaError::App(err))) = self.checkpoints.last_completed_index() {
+            if err == "No completed checkpoints yet" {
+                return Ok(vec![]);
+            }
+        }
+
+        // TODO: drain iter
+        let pending = &mut self.checkpoints.last_completed_mut()?.pending;
+        let keys = pending
+            .iter()?
+            .map(|entry| entry.map(|(dest, _)| dest.clone()).map_err(Error::from))
+            .collect::<Result<Vec<Dest>>>()?;
+        let mut dests = vec![];
+        for dest in keys {
+            let coins = pending.remove(dest.clone())?.unwrap().into_inner();
+            dests.push((dest, coins));
+        }
+        Ok(dests)
+    }
 }
 
 #[orga]
@@ -812,7 +837,7 @@ mod tests {
                 Adapter::new(PartialMerkleTree::from_txids(&[Txid::all_zeros()], &[true])),
                 0,
                 0,
-                &[],
+                Dest::Address(Address::NULL),
             )
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -280,6 +280,21 @@ pub async fn poll_for_signatory_key() {
     }
 }
 
+pub async fn poll_for_signing_checkpoint() {
+    info!("Scanning for signing checkpoint...");
+
+    loop {
+        let has_signing = app_client(DEFAULT_RPC)
+            .query(|app| Ok(app.bitcoin.checkpoints.signing()?.is_some()))
+            .await
+            .unwrap();
+        if has_signing {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
 pub async fn poll_for_completed_checkpoint(num_checkpoints: u32) {
     info!("Scanning for signed checkpoints...");
     let mut checkpoint_len = app_client(DEFAULT_RPC)

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -7,7 +7,7 @@ use bitcoind::bitcoincore_rpc::json::{
 use bitcoind::bitcoincore_rpc::RpcApi;
 use bitcoind::{BitcoinD, Conf};
 use log::info;
-use nomic::app::DepositCommitment;
+use nomic::app::Dest;
 use nomic::app::{InnerApp, Nom};
 use nomic::bitcoin::adapter::Adapter;
 use nomic::bitcoin::relayer::DepositAddress;
@@ -48,11 +48,7 @@ async fn generate_deposit_address(address: &Address) -> Result<DepositAddress> {
     let sigset = app_client()
         .query(|app| Ok(app.bitcoin.checkpoints.active_sigset()?))
         .await?;
-    let script = sigset.output_script(
-        DepositCommitment::Address(*address)
-            .commitment_bytes()?
-            .as_slice(),
-    )?;
+    let script = sigset.output_script(Dest::Address(*address).commitment_bytes()?.as_slice())?;
 
     Ok(DepositAddress {
         deposit_addr: bitcoin::Address::from_script(&script, bitcoin::Network::Regtest)
@@ -71,7 +67,7 @@ pub async fn broadcast_deposit_addr(
     info!("Broadcasting deposit address to relayer...");
     let dest_addr = dest_addr.parse().unwrap();
 
-    let commitment = DepositCommitment::Address(dest_addr).encode()?;
+    let commitment = Dest::Address(dest_addr).encode()?;
 
     let url = format!("{}/address", relayer,);
     let client = reqwest::Client::new();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -10,7 +10,7 @@ use nomic::orga::Error as OrgaError;
 use std::str::FromStr;
 // use crate::web_client::WebClient;
 use js_sys::{Array, Uint8Array};
-use nomic::app::{App, DepositCommitment, InnerApp, Nom};
+use nomic::app::{App, Dest, InnerApp, Nom};
 use nomic::bitcoin::{Nbtc, NETWORK as BITCOIN_NETWORK};
 use nomic::orga::client::wallet::Unsigned;
 use nomic::orga::client::AppClient;
@@ -424,11 +424,7 @@ pub async fn gen_deposit_addr(dest_addr: String) -> Result<DepositAddress, JsErr
     let sigset = app_client()
         .query(|app: InnerApp| Ok(app.bitcoin.checkpoints.active_sigset()?))
         .await?;
-    let script = sigset.output_script(
-        DepositCommitment::Address(dest_addr)
-            .commitment_bytes()?
-            .as_slice(),
-    )?;
+    let script = sigset.output_script(Dest::Address(dest_addr).commitment_bytes()?.as_slice())?;
     // TODO: get network from somewhere
     // TODO: make test/mainnet option configurable
     let btc_addr = bitcoin::Address::from_script(&script, BITCOIN_NETWORK)?;
@@ -501,7 +497,7 @@ pub async fn broadcast_deposit_addr(
         .parse()
         .map_err(|e| Error::Wasm(format!("{:?}", e)))?;
 
-    let commitment = DepositCommitment::Address(dest_addr);
+    let commitment = Dest::Address(dest_addr);
 
     let window = match web_sys::window() {
         Some(window) => window,


### PR DESCRIPTION
NBTC transfers and deposits previously were processed instantly, creating a divergence between account balances and the most recently signed emergency disbursal. This PR changes movements of NBTC to only be processed once the next checkpoint is signed, so that all NBTC (other than dust accounts) is always backed by emergency disbursal outputs.