### PR TITLE
Change stakenet upgrades to activate Wednesdays

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1129,12 +1129,12 @@ pub fn in_upgrade_window(now_seconds: i64) -> bool {
     let now = Utc.timestamp_opt(now_seconds, 0).unwrap();
 
     #[cfg(not(feature = "testnet"))]
-    let valid_weekday = now.weekday().num_days_from_monday() == 2;  // Wednesday
+    let valid_weekday = now.weekday().num_days_from_monday() == 2; // Wednesday
 
     #[cfg(feature = "testnet")]
-    let valid_weekday = now.weekday().num_days_from_monday() < 5;   // Monday - Friday
-    
-    valid_weekday && now.hour() == 17 && now.minute() < 10  // 17:00 - 17:10 UTC
+    let valid_weekday = now.weekday().num_days_from_monday() < 5; // Monday - Friday
+
+    valid_weekday && now.hour() == 17 && now.minute() < 10 // 17:00 - 17:10 UTC
 }
 
 #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1128,7 +1128,12 @@ pub fn in_upgrade_window(now_seconds: i64) -> bool {
     use chrono::prelude::*;
     let now = Utc.timestamp_opt(now_seconds, 0).unwrap();
 
-    // Monday - Friday, 17:00 - 17:10 UTC
+    // Wednesday, 17:00 - 17:10 UTC
+    #[cfg(not(feature = "testnet"))]
+    now.weekday().num_days_from_monday() == 2 && now.hour() == 17 && now.minute() < 10
+
+     // Monday - Friday, 17:00 - 17:10 UTC
+    #[cfg(feature = "testnet")]
     now.weekday().num_days_from_monday() < 5 && now.hour() == 17 && now.minute() < 10
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1128,13 +1128,13 @@ pub fn in_upgrade_window(now_seconds: i64) -> bool {
     use chrono::prelude::*;
     let now = Utc.timestamp_opt(now_seconds, 0).unwrap();
 
-    // Wednesday, 17:00 - 17:10 UTC
     #[cfg(not(feature = "testnet"))]
-    now.weekday().num_days_from_monday() == 2 && now.hour() == 17 && now.minute() < 10
+    let valid_weekday = now.weekday().num_days_from_monday() == 2;  // Wednesday
 
-     // Monday - Friday, 17:00 - 17:10 UTC
     #[cfg(feature = "testnet")]
-    now.weekday().num_days_from_monday() < 5 && now.hour() == 17 && now.minute() < 10
+    let valid_weekday = now.weekday().num_days_from_monday() < 5;   // Monday - Friday
+    
+    valid_weekday && now.hour() == 17 && now.minute() < 10  // 17:00 - 17:10 UTC
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR separates stakenet from testnet upgrade activations to activate Wednesdays at 17:00 - 17:10 UTC to provide more predictable activation windows.