### PR TITLE
nBTC call fees

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-// TODO: remove after swtiching from "testnet" feature flag to orga channels
+// TODO: remove after switching from "testnet" feature flag to orga channels
 #![allow(unused_variables)]
 #![allow(unused_imports)]
 
@@ -31,6 +31,7 @@ use orga::ibc::{Ibc, IbcTx};
 
 use orga::ibc::ibc_rs::Signer as IbcSigner;
 
+use orga::coins::Declaration;
 use orga::encoding::Adapter as EdAdapter;
 use orga::macros::build_call;
 use orga::migrate::Migrate;
@@ -289,7 +290,7 @@ impl InnerApp {
     pub fn ibc_deliver(&mut self, messages: RawIbcTx) -> Result<()> {
         #[cfg(feature = "testnet")]
         {
-            self.deduct_nbtc_ibc_fee(IBC_FEE_USATS.into())?;
+            self.deduct_nbtc_fee(IBC_FEE_USATS.into())?;
             let incoming_transfers = self.ibc.deliver(messages)?;
 
             for transfer in incoming_transfers {
@@ -320,7 +321,7 @@ impl InnerApp {
 
     #[call]
     pub fn declare_with_nbtc(&mut self, declaration: Declaration) -> Result<()> {
-        self.deduct_nbtc_fee(DECLARE_FEE_USATS.into());
+        self.deduct_nbtc_fee(DECLARE_FEE_USATS.into())?;
         let signer = self.signer()?;
         self.staking.declare(signer, declaration, 0.into())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,7 @@ const STRATEGIC_RESERVE_ADDRESS: &str = "nomic1d5n325zrf4elfu0heqd59gna5j6xyunhe
 const VALIDATOR_BOOTSTRAP_ADDRESS: &str = "nomic1fd9mxxt84lw3jdcsmjh6jy8m6luafhqd8dcqeq";
 
 const IBC_FEE_USATS: u64 = 1_000_000;
+const DECLARE_FEE_USATS: u64 = 100_000_000;
 
 #[orga(version = 2)]
 pub struct InnerApp {
@@ -317,7 +318,14 @@ impl InnerApp {
         Err(orga::Error::Unknown)
     }
 
-    fn deduct_nbtc_ibc_fee(&mut self, amount: Amount) -> Result<()> {
+    #[call]
+    pub fn declare_with_nbtc(&mut self, declaration: Declaration) -> Result<()> {
+        self.deduct_nbtc_fee(DECLARE_FEE_USATS.into());
+        let signer = self.signer()?;
+        self.staking.declare(signer, declaration, 0.into())
+    }
+
+    fn deduct_nbtc_fee(&mut self, amount: Amount) -> Result<()> {
         disable_fee();
         let signer = self.signer()?;
         self.bitcoin.accounts.withdraw(signer, amount)?.burn();


### PR DESCRIPTION
This PR adds support for paying fees with nBTC instead of NOM for IBC message relaying and validator declaration.