### PR TITLE
Remote chain emergency disbursal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "git+https://github.com/nomic-io/abci2?rev=26b345ed839123f33596a2f3b564
 dependencies = [
  "log",
  "prost",
- "tendermint-proto 0.32.0",
+ "tendermint-proto",
  "thiserror",
 ]
 
@@ -807,7 +807,7 @@ checksum = "73c9d2043a9e617b0d602fbc0a0ecd621568edbf3a9774890a6d562389bd8e1c"
 dependencies = [
  "prost",
  "prost-types",
- "tendermint-proto 0.32.0",
+ "tendermint-proto",
  "tonic",
 ]
 
@@ -827,7 +827,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint 0.32.0",
+ "tendermint",
  "thiserror",
 ]
 
@@ -1904,9 +1904,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "subtle-encoding",
- "tendermint 0.32.0",
+ "tendermint",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.32.0",
+ "tendermint-proto",
  "time 0.3.24",
  "tracing",
  "uint",
@@ -1938,7 +1938,7 @@ dependencies = [
  "prost",
  "serde",
  "subtle-encoding",
- "tendermint-proto 0.32.0",
+ "tendermint-proto",
  "tonic",
 ]
 
@@ -2274,7 +2274,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 [[package]]
 name = "merk"
 version = "2.0.0"
-source = "git+https://github.com/nomic-io/merk?rev=db64bb3024eee6c1e77861d645d20110b1fe549b#db64bb3024eee6c1e77861d645d20110b1fe549b"
+source = "git+https://github.com/nomic-io/merk?rev=33beb3334e6a55d6f72a55e4bb06af73e8af8904#33beb3334e6a55d6f72a55e4bb06af73e8af8904"
 dependencies = [
  "byteorder",
  "colored",
@@ -2436,7 +2436,7 @@ dependencies = [
  "sha2 0.10.7",
  "split-iter",
  "tempfile",
- "tendermint-rpc 0.30.0",
+ "tendermint-rpc",
  "thiserror",
  "tokio",
  "toml 0.7.8",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=8cfabc72b05d2f10fcad168876e1a9e8e72db880#8cfabc72b05d2f10fcad168876e1a9e8e72db880"
+source = "git+https://github.com/nomic-io/orga.git?rev=1bb08e513b133adc8166980d047f8e3f9a9b668f#1bb08e513b133adc8166980d047f8e3f9a9b668f"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2622,9 +2622,9 @@ dependencies = [
  "sha2 0.10.7",
  "sha3",
  "tar",
- "tendermint 0.32.0",
- "tendermint-proto 0.32.0",
- "tendermint-rpc 0.32.0",
+ "tendermint",
+ "tendermint-proto",
+ "tendermint-rpc",
  "thiserror",
  "tokio",
  "toml_edit 0.19.15",
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=8cfabc72b05d2f10fcad168876e1a9e8e72db880#8cfabc72b05d2f10fcad168876e1a9e8e72db880"
+source = "git+https://github.com/nomic-io/orga.git?rev=1bb08e513b133adc8166980d047f8e3f9a9b668f#1bb08e513b133adc8166980d047f8e3f9a9b668f"
 dependencies = [
  "darling",
  "heck 0.3.3",
@@ -4007,35 +4007,6 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
-dependencies = [
- "bytes",
- "digest 0.10.7",
- "ed25519 1.5.3",
- "ed25519-consensus",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.10.7",
- "signature 1.6.4",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.30.0",
- "time 0.3.24",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a46ec6b25b028097ab682ffae11d09d64fe1e2535833b902f26a278a0f88a705"
@@ -4060,23 +4031,9 @@ dependencies = [
  "signature 2.1.0",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.32.0",
+ "tendermint-proto",
  "time 0.3.24",
  "zeroize",
-]
-
-[[package]]
-name = "tendermint-config"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74efd33bcb53413b77cbe90ccb2cf0403930a5c1f300725deb87a61f7c4fab90"
-dependencies = [
- "flex-error",
- "serde",
- "serde_json",
- "tendermint 0.30.0",
- "toml 0.5.11",
- "url",
 ]
 
 [[package]]
@@ -4088,7 +4045,7 @@ dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.32.0",
+ "tendermint",
  "toml 0.5.11",
  "url",
 ]
@@ -4102,25 +4059,7 @@ dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint 0.32.0",
- "time 0.3.24",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
+ "tendermint",
  "time 0.3.24",
 ]
 
@@ -4140,40 +4079,6 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "time 0.3.24",
-]
-
-[[package]]
-name = "tendermint-rpc"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79bd426571d6a805be5c0b6749707ede6c6ee5e55dd45baef46857a1baa9f54"
-dependencies = [
- "async-trait",
- "bytes",
- "flex-error",
- "futures",
- "getrandom 0.2.10",
- "http",
- "hyper",
- "hyper-proxy",
- "hyper-rustls",
- "peg",
- "pin-project",
- "semver 1.0.18",
- "serde",
- "serde_bytes",
- "serde_json",
- "subtle",
- "subtle-encoding",
- "tendermint 0.30.0",
- "tendermint-config 0.30.0",
- "thiserror",
- "time 0.3.24",
- "tokio",
- "tracing",
- "url",
- "uuid 0.8.2",
- "walkdir",
 ]
 
 [[package]]
@@ -4199,9 +4104,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint 0.32.0",
- "tendermint-config 0.32.0",
- "tendermint-proto 0.32.0",
+ "tendermint",
+ "tendermint-config",
+ "tendermint-proto",
  "thiserror",
  "time 0.3.24",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tendermint-proto 0.32.0",
+ "tonic",
 ]
 
 [[package]]
@@ -1938,14 +1939,12 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9e8f569c5cc88e08b8d076dc207e0748aa1f52d4b84910ec919c8f2bed6ea7"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "pbjson",
+ "informalsystems-pbjson",
  "prost",
  "ripemd",
  "serde",
@@ -2033,6 +2032,16 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eecd90f87bea412eac91c6ef94f6b1e390128290898cbe14f2b926787ae1fb"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2394,6 +2403,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "cosmos-sdk-proto",
  "crossbeam-channel",
  "csv",
  "curl",
@@ -2402,6 +2412,7 @@ dependencies = [
  "futures",
  "hex",
  "home",
+ "ics23",
  "js-sys",
  "log",
  "mutagen",
@@ -2695,16 +2706,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbjson"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
-dependencies = [
- "base64 0.13.1",
- "serde",
-]
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.29.2", features = ["serde", "rand"] }
 bitcoind = { version = "0.27.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "8cfabc72b05d2f10fcad168876e1a9e8e72db880", features = [
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "1bb08e513b133adc8166980d047f8e3f9a9b668f", features = [
     "merk-verify",
 ] }
 thiserror = "1.0.30"
@@ -23,7 +23,7 @@ csv = { version = "1.1.6", optional = true }
 bech32 = { version = "0.9.1" }
 futures = "0.3.21"
 toml_edit = "0.13.4"
-tendermint-rpc = { version = "=0.30.0", features = [
+tendermint-rpc = { version = "=0.32.0", features = [
     "http-client",
 ], optional = true }
 bitcoincore-rpc-async = { package = "bitcoincore-rpc-async2", version = "4.0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3"
 home = { version = "0.5.5", optional = true }
 semver = "1.0.18"
 ics23 = "0.10.2"
-cosmos-sdk-proto = "0.19.0"
+cosmos-sdk-proto = {version = "0.19.0", optional = true }
 
 [dev-dependencies]
 bitcoin_hashes = "0.11.0"
@@ -78,6 +78,7 @@ full = [
     "rand",
     "reqwest",
     "tendermint-rpc",
+    "cosmos-sdk-proto",
     "home",
 ]
 feat-ibc = ["orga/feat-ibc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ chrono = "0.4.19"
 tempfile = "3"
 home = { version = "0.5.5", optional = true }
 semver = "1.0.18"
+ics23 = "0.10.2"
+cosmos-sdk-proto = "0.19.0"
 
 [dev-dependencies]
 bitcoin_hashes = "0.11.0"

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "prost 0.11.9",
  "prost-types 0.11.9",
  "tendermint-proto 0.32.0",
+ "tonic",
 ]
 
 [[package]]
@@ -1981,14 +1982,14 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9e8f569c5cc88e08b8d076dc207e0748aa1f52d4b84910ec919c8f2bed6ea7"
+checksum = "442d4bab37956e76f739c864f246c825d87c0bb7f9afa65660c57833c91bf6d4"
 dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "pbjson",
+ "informalsystems-pbjson",
  "prost 0.11.9",
  "ripemd",
  "serde",
@@ -2077,6 +2078,16 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eecd90f87bea412eac91c6ef94f6b1e390128290898cbe14f2b926787ae1fb"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2331,7 +2342,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "merk"
 version = "2.0.0"
-source = "git+https://github.com/nomic-io/merk?rev=db64bb3024eee6c1e77861d645d20110b1fe549b#db64bb3024eee6c1e77861d645d20110b1fe549b"
+source = "git+https://github.com/nomic-io/merk?rev=33beb3334e6a55d6f72a55e4bb06af73e8af8904#33beb3334e6a55d6f72a55e4bb06af73e8af8904"
 dependencies = [
  "byteorder",
  "colored",
@@ -2460,12 +2471,14 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "cosmos-sdk-proto",
  "csv",
  "derive_more",
  "ed 0.3.0 (git+https://github.com/nomic-io/ed?rev=9c0e206ffdb59dacb90f083e004e8080713e6ad8)",
  "futures",
  "hex",
  "home",
+ "ics23",
  "js-sys",
  "log",
  "orga",
@@ -2479,7 +2492,7 @@ dependencies = [
  "sha2 0.10.7",
  "split-iter",
  "tempfile",
- "tendermint-rpc 0.30.0",
+ "tendermint-rpc 0.32.0",
  "thiserror",
  "tokio",
  "toml 0.7.6",
@@ -2653,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=2ee12867393ba63859a7bacbdf5a883dc4a54c3f#2ee12867393ba63859a7bacbdf5a883dc4a54c3f"
+source = "git+https://github.com/nomic-io/orga.git?rev=1bb08e513b133adc8166980d047f8e3f9a9b668f#1bb08e513b133adc8166980d047f8e3f9a9b668f"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2714,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=2ee12867393ba63859a7bacbdf5a883dc4a54c3f#2ee12867393ba63859a7bacbdf5a883dc4a54c3f"
+source = "git+https://github.com/nomic-io/orga.git?rev=1bb08e513b133adc8166980d047f8e3f9a9b668f#1bb08e513b133adc8166980d047f8e3f9a9b668f"
 dependencies = [
  "darling",
  "heck 0.3.3",
@@ -2797,16 +2810,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbjson"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
-dependencies = [
- "base64 0.13.1",
- "serde",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -4334,35 +4337,6 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
-dependencies = [
- "bytes",
- "digest 0.10.7",
- "ed25519 1.5.3",
- "ed25519-consensus",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.10.7",
- "signature 1.6.4",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.30.0",
- "time 0.3.11",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a46ec6b25b028097ab682ffae11d09d64fe1e2535833b902f26a278a0f88a705"
@@ -4408,20 +4382,6 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74efd33bcb53413b77cbe90ccb2cf0403930a5c1f300725deb87a61f7c4fab90"
-dependencies = [
- "flex-error",
- "serde",
- "serde_json",
- "tendermint 0.30.0",
- "toml 0.5.11",
- "url",
-]
-
-[[package]]
-name = "tendermint-config"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dbb7610ef8422d5886116868e48ab6a9ea72859b3bf9021c6d87318e5600225"
@@ -4452,24 +4412,6 @@ name = "tendermint-proto"
 version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ce80bf536476db81ecc9ebab834dc329c9c1509a694f211a73858814bfe023"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time 0.3.11",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4525,40 +4467,6 @@ dependencies = [
  "tendermint 0.23.7",
  "tendermint-config 0.23.7",
  "tendermint-proto 0.23.9",
- "thiserror",
- "time 0.3.11",
- "tokio",
- "tracing",
- "url",
- "uuid 0.8.2",
- "walkdir",
-]
-
-[[package]]
-name = "tendermint-rpc"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79bd426571d6a805be5c0b6749707ede6c6ee5e55dd45baef46857a1baa9f54"
-dependencies = [
- "async-trait",
- "bytes",
- "flex-error",
- "futures",
- "getrandom 0.2.10",
- "http",
- "hyper",
- "hyper-proxy",
- "hyper-rustls",
- "peg",
- "pin-project",
- "semver 1.0.18",
- "serde",
- "serde_bytes",
- "serde_json",
- "subtle",
- "subtle-encoding",
- "tendermint 0.30.0",
- "tendermint-config 0.30.0",
  "thiserror",
  "time 0.3.11",
  "tokio",

--- a/src/app.rs
+++ b/src/app.rs
@@ -462,9 +462,12 @@ mod abci {
             for (dest, coins) in pending_nbtc_transfers {
                 self.credit_transfer(dest, coins)?;
             }
-            let external_outputs = self
-                .cosmos
-                .build_outputs(&self.ibc, self.bitcoin.checkpoints.index)?;
+            let external_outputs = if self.bitcoin.should_push_checkpoint()? {
+                self.cosmos
+                    .build_outputs(&self.ibc, self.bitcoin.checkpoints.index)?
+            } else {
+                vec![]
+            };
             let offline_signers = self
                 .bitcoin
                 .begin_block_step(external_outputs.into_iter().map(|v| Ok(v)))?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -486,7 +486,7 @@ mod abci {
             };
             let offline_signers = self
                 .bitcoin
-                .begin_block_step(external_outputs.into_iter().map(|v| Ok(v)))?;
+                .begin_block_step(external_outputs.into_iter().map(Ok))?;
             for cons_key in offline_signers {
                 let address = self.staking.address_by_consensus_key(cons_key)?.unwrap();
                 self.staking.punish_downtime(address)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1205,7 +1205,14 @@ mod tests {
 
     #[test]
     fn upgrade_date() {
+        #[cfg(feature = "testnet")]
         assert!(in_upgrade_window(1690218300)); // Monday 17:05 UTC
+        #[cfg(not(feature = "testnet"))]
+        assert!(!in_upgrade_window(1690218300)); // Monday 17:05 UTC
+        #[cfg(feature = "testnet")]
+        assert!(in_upgrade_window(1690391100)); // Wednesday 17:05 UTC
+        #[cfg(not(feature = "testnet"))]
+        assert!(in_upgrade_window(1690391100)); // Wednesday 17:05 UTC
         assert!(!in_upgrade_window(1690219200)); // Monday 17:20 UTC
         assert!(!in_upgrade_window(1690736700)); // Sunday 17:05 UTC
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@
 use crate::airdrop::Airdrop;
 use crate::bitcoin::adapter::Adapter;
 use crate::bitcoin::{Bitcoin, Nbtc};
+use crate::cosmos::{Chain, Cosmos, Proof};
 use crate::incentives::Incentives;
 use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{Script, Transaction, TxOut};
@@ -27,11 +28,10 @@ use orga::ibc::ibc_rs::core::ics04_channel::timeout::TimeoutHeight;
 use orga::ibc::ibc_rs::core::ics24_host::identifier::{ChannelId, PortId};
 use orga::ibc::ibc_rs::core::timestamp::Timestamp;
 #[cfg(feature = "testnet")]
-use orga::ibc::{Ibc, IbcTx};
+use orga::ibc::{ClientId, Ibc, IbcTx};
 
 use orga::ibc::ibc_rs::Signer as IbcSigner;
 
-use super::cosmos::Cosmos;
 use orga::coins::Declaration;
 use orga::encoding::Adapter as EdAdapter;
 use orga::macros::build_call;
@@ -248,6 +248,22 @@ impl InnerApp {
             sigset_index,
             dest,
         )?)
+    }
+
+    #[call]
+    pub fn relay_op_key(
+        &mut self,
+        client_id: ClientId,
+        height: (u64, u64),
+        cons_key: LengthVec<u8, u8>,
+        op_addr: Proof,
+        acc: Proof,
+    ) -> Result<()> {
+        self.deduct_nbtc_fee(IBC_FEE_USATS.into())?;
+
+        Ok(self
+            .cosmos
+            .relay_op_key(&self.ibc, client_id, height, cons_key, op_addr, acc)?)
     }
 
     pub fn credit_transfer(&mut self, dest: Dest, nbtc: Coin<Nbtc>) -> Result<()> {

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -100,6 +100,7 @@ pub enum Command {
     IbcTransfer(IbcTransferCmd),
     Export(ExportCmd),
     UpgradeStatus(UpgradeStatusCmd),
+    #[cfg(feature = "testnet")]
     RelayOpKeys(RelayOpKeysCmd),
 }
 
@@ -152,6 +153,7 @@ impl Command {
                 IbcTransfer(cmd) => cmd.run().await,
                 Export(cmd) => cmd.run().await,
                 UpgradeStatus(cmd) => cmd.run().await,
+                #[cfg(feature = "testnet")]
                 RelayOpKeys(cmd) => cmd.run().await,
             }
         })
@@ -1691,12 +1693,14 @@ impl UpgradeStatusCmd {
     }
 }
 
+#[cfg(feature = "testnet")]
 #[derive(Parser, Debug)]
 pub struct RelayOpKeysCmd {
     client_id: String,
     rpc_url: String,
 }
 
+#[cfg(feature = "testnet")]
 impl RelayOpKeysCmd {
     async fn run(&self) -> Result<()> {
         use nomic::cosmos::relay_op_keys;

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -100,6 +100,7 @@ pub enum Command {
     IbcTransfer(IbcTransferCmd),
     Export(ExportCmd),
     UpgradeStatus(UpgradeStatusCmd),
+    RelayOpKeys(RelayOpKeysCmd),
 }
 
 impl Command {
@@ -151,6 +152,7 @@ impl Command {
                 IbcTransfer(cmd) => cmd.run().await,
                 Export(cmd) => cmd.run().await,
                 UpgradeStatus(cmd) => cmd.run().await,
+                RelayOpKeys(cmd) => cmd.run().await,
             }
         })
     }
@@ -1684,6 +1686,31 @@ impl UpgradeStatusCmd {
         } else {
             println!("Upgrade requires {:.2}% of voting power", threshold * 100.0);
         }
+
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct RelayOpKeysCmd {
+    client_id: String,
+    rpc_url: String,
+}
+
+impl RelayOpKeysCmd {
+    async fn run(&self) -> Result<()> {
+        use nomic::cosmos::relay_op_keys;
+        log::info!("Relaying operator keys for client {}", self.client_id);
+        let bytes = format!("{}/", self.client_id).as_bytes().to_vec();
+        let client_id = Decode::decode(&mut bytes.as_slice())?;
+        relay_op_keys(
+            || nomic::app_client("http://localhost:26657").with_wallet(wallet()),
+            client_id,
+            self.rpc_url.as_str(),
+        )
+        .await?;
+
+        log::info!("Finished relaying operator keys");
 
         Ok(())
     }

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1197,6 +1197,7 @@ impl CheckpointQueue {
         Ok(true)
     }
 
+    #[cfg(feature = "full")]
     pub fn should_push(&mut self, sig_keys: &Map<ConsensusKey, Xpub>) -> Result<bool> {
         if self.signing()?.is_some() {
             return Ok(false);

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1142,37 +1142,8 @@ impl CheckpointQueue {
         recovery_scripts: &Map<orga::coins::Address, Adapter<bitcoin::Script>>,
         external_outputs: impl Iterator<Item = Result<bitcoin::TxOut>>,
     ) -> Result<bool> {
-        if self.signing()?.is_some() {
+        if !self.should_push(sig_keys)? {
             return Ok(false);
-        }
-
-        if !self.queue.is_empty() {
-            let now = self
-                .context::<Time>()
-                .ok_or_else(|| OrgaError::App("No time context".to_string()))?
-                .seconds as u64;
-            let elapsed = now - self.building()?.create_time();
-            if elapsed < self.config.min_checkpoint_interval {
-                return Ok(false);
-            }
-
-            if elapsed < self.config.max_checkpoint_interval || self.index == 0 {
-                let building = self.building()?;
-                let checkpoint_tx = building.checkpoint_tx()?;
-
-                let has_pending_deposit = if self.index == 0 {
-                    !checkpoint_tx.input.is_empty()
-                } else {
-                    checkpoint_tx.input.len() > 1
-                };
-
-                let has_pending_withdrawal = !checkpoint_tx.output.is_empty();
-                let has_pending_transfers = building.pending.iter()?.next().transpose()?.is_some();
-
-                if !has_pending_deposit && !has_pending_withdrawal && !has_pending_transfers {
-                    return Ok(false);
-                }
-            }
         }
 
         if self.maybe_push(sig_keys)?.is_none() {
@@ -1221,6 +1192,58 @@ impl CheckpointQueue {
                 let data = output.into_inner();
                 checkpoint_tx.output.push_back(data)?;
             }
+        }
+
+        Ok(true)
+    }
+
+    pub fn should_push(&mut self, sig_keys: &Map<ConsensusKey, Xpub>) -> Result<bool> {
+        if self.signing()?.is_some() {
+            return Ok(false);
+        }
+
+        if !self.queue.is_empty() {
+            let now = self
+                .context::<Time>()
+                .ok_or_else(|| OrgaError::App("No time context".to_string()))?
+                .seconds as u64;
+            let elapsed = now - self.building()?.create_time();
+            if elapsed < self.config.min_checkpoint_interval {
+                return Ok(false);
+            }
+
+            if elapsed < self.config.max_checkpoint_interval || self.index == 0 {
+                let building = self.building()?;
+                let checkpoint_tx = building.checkpoint_tx()?;
+
+                let has_pending_deposit = if self.index == 0 {
+                    !checkpoint_tx.input.is_empty()
+                } else {
+                    checkpoint_tx.input.len() > 1
+                };
+
+                let has_pending_withdrawal = !checkpoint_tx.output.is_empty();
+                let has_pending_transfers = building.pending.iter()?.next().transpose()?.is_some();
+
+                if !has_pending_deposit && !has_pending_withdrawal && !has_pending_transfers {
+                    return Ok(false);
+                }
+            }
+        }
+
+        let mut index = self.index;
+        if !self.queue.is_empty() {
+            index += 1;
+        }
+
+        let sigset = SignatorySet::from_validator_ctx(index, sig_keys)?;
+
+        if sigset.possible_vp() == 0 {
+            return Ok(false);
+        }
+
+        if !sigset.has_quorum() {
+            return Ok(false);
         }
 
         Ok(true)

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -320,6 +320,10 @@ impl Bitcoin {
         Ok(())
     }
 
+    pub fn should_push_checkpoint(&mut self) -> Result<bool> {
+        self.checkpoints.should_push(self.signatory_keys.map())
+    }
+
     pub fn relay_deposit(
         &mut self,
         btc_tx: Adapter<Transaction>,

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -324,6 +324,7 @@ impl Bitcoin {
         Ok(())
     }
 
+    #[cfg(feature = "full")]
     pub fn should_push_checkpoint(&mut self) -> Result<bool> {
         self.checkpoints.should_push(self.signatory_keys.map())
     }

--- a/src/bitcoin/threshold_sig.rs
+++ b/src/bitcoin/threshold_sig.rs
@@ -82,6 +82,17 @@ impl Pubkey {
         Pubkey { bytes: pubkey }
     }
 
+    pub fn try_from_slice(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != PUBLIC_KEY_SIZE {
+            return Err(Error::App("Incorrect length".to_string()));
+        }
+
+        let mut buf = [0; PUBLIC_KEY_SIZE];
+        buf.copy_from_slice(bytes);
+
+        Ok(Self::new(buf))
+    }
+
     pub fn as_slice(&self) -> &[u8] {
         &self.bytes
     }

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -1,0 +1,242 @@
+use crate::{bitcoin::threshold_sig::Pubkey, error::Result};
+use ibc::{
+    clients::ics07_tendermint,
+    core::{
+        ics02_client::consensus_state::ConsensusState, ics23_commitment::commitment::CommitmentRoot,
+    },
+};
+use ics23::ExistenceProof;
+use orga::{
+    abci::prost::Adapter,
+    collections::Map,
+    cosmrs::proto,
+    encoding::LengthVec,
+    ibc::ibc_rs::{self as ibc},
+    ibc::{ibc_rs::Height, ClientId, Ibc},
+    orga, Error as OrgaError,
+};
+use proto::traits::{Message, MessageExt};
+
+#[orga]
+pub struct Cosmos {
+    pub chains: Map<ClientId, Chain>,
+}
+
+#[orga]
+impl Cosmos {
+    pub fn relay_op_key(
+        &mut self,
+        ibc: &Ibc,
+        client_id: ClientId,
+        height: (u64, u64),
+        cons_key: LengthVec<u8, u8>,
+        op_addr: Proof,
+        acc: Proof,
+    ) -> Result<()> {
+        let client = ibc
+            .clients
+            .get(client_id.clone())?
+            .ok_or_else(|| OrgaError::Ibc("Client not found".to_string()))?;
+
+        if client.client_type()? != ics07_tendermint::client_type() {
+            return Err(OrgaError::Ibc("Only supported for Tendermint clients".to_string()).into());
+        }
+
+        let epoch_height = Height::new(height.0, height.1)
+            .map_err(|_| OrgaError::Ibc("Invalid height".to_string()))?;
+        let cons_state = client
+            .consensus_states
+            .get(epoch_height.into())?
+            .ok_or_else(|| OrgaError::Ibc("No consensus state for given height".to_string()))?;
+        let root = cons_state.root();
+
+        // TODO: verify consensus key is in validator set
+
+        op_addr.verify(root, "staking")?;
+        acc.verify(root, "acc")?;
+
+        let calc_op_addr = tmhash(cons_key.as_slice());
+        if op_addr.key()? != &vec![&[0x22, 0x14], calc_op_addr.as_slice()].concat() {
+            return Err(OrgaError::App(
+                "Consensus address does not match consensus key".to_string(),
+            )
+            .into());
+        }
+
+        if acc.key()? != &vec![&[0x01], op_addr.value()?.as_slice()].concat() {
+            return Err(
+                OrgaError::App("Account does not match operator address".to_string()).into(),
+            );
+        }
+
+        let any = proto::Any::decode(acc.value()?.as_slice())
+            .map_err(|_| OrgaError::App("Failed to decode account protobuf".to_string()))?;
+        let acc = proto::cosmos::auth::v1beta1::BaseAccount::from_any(&any)
+            .map_err(|_| OrgaError::App("Invalid account".to_string()))?;
+
+        let op_key_any = acc
+            .pub_key
+            .ok_or_else(|| OrgaError::App("Expected public key".to_string()))?;
+        let op_key = Pubkey::try_from_slice(
+            proto::cosmos::crypto::secp256k1::PubKey::from_any(&op_key_any)
+                .map_err(|_| OrgaError::App("Invalid public key".to_string()))?
+                .key
+                .as_slice(),
+        )?;
+
+        let mut chain = self.chains.entry(client_id)?.or_default()?;
+        chain.op_keys_by_cons.insert(cons_key, op_key)?;
+
+        Ok(())
+    }
+}
+
+pub fn tmhash(bytes: &[u8]) -> [u8; 20] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+
+    let mut output = [0; 20];
+    output.copy_from_slice(&hash[..20]);
+    output
+}
+
+pub struct Proof {
+    pub inner: Adapter<ics23::CommitmentProof>,
+    pub outer: Adapter<ics23::CommitmentProof>,
+}
+
+impl Proof {
+    pub fn verify(&self, root: &CommitmentRoot, store: &str) -> Result<()> {
+        let inner_root = &self.outer_proof()?.value;
+        if !ics23::verify_membership::<ics23::HostFunctionsManager>(
+            &self.outer,
+            &ics23::tendermint_spec(),
+            &root.clone().into_vec(),
+            store.as_bytes(),
+            inner_root,
+        ) {
+            return Err(OrgaError::Ibc("Invalid outer proof".to_string()).into());
+        }
+
+        if !ics23::verify_membership::<ics23::HostFunctionsManager>(
+            &self.inner,
+            &ics23::iavl_spec(),
+            inner_root,
+            self.key()?,
+            self.value()?,
+        ) {
+            return Err(OrgaError::Ibc("Invalid inner proof".to_string()).into());
+        }
+
+        Ok(())
+    }
+
+    pub fn key(&self) -> Result<&Vec<u8>> {
+        Ok(&self.inner_proof()?.key)
+    }
+
+    pub fn value(&self) -> Result<&Vec<u8>> {
+        Ok(&self.inner_proof()?.value)
+    }
+
+    pub fn outer_proof(&self) -> Result<&ExistenceProof> {
+        let proof = self
+            .outer
+            .proof
+            .as_ref()
+            .ok_or_else(|| OrgaError::Ibc("Expected proof".to_string()))?;
+        if let ics23::commitment_proof::Proof::Exist(proof) = proof {
+            Ok(proof)
+        } else {
+            Err(OrgaError::Ibc("Expected existence proof".to_string()).into())
+        }
+    }
+
+    pub fn inner_proof(&self) -> Result<&ExistenceProof> {
+        let proof = self
+            .inner
+            .proof
+            .as_ref()
+            .ok_or_else(|| OrgaError::Ibc("Expected proof".to_string()))?;
+        if let ics23::commitment_proof::Proof::Exist(proof) = proof {
+            Ok(proof)
+        } else {
+            Err(OrgaError::Ibc("Expected existence proof".to_string()).into())
+        }
+    }
+}
+
+#[orga]
+pub struct Chain {
+    pub op_keys_by_cons: Map<LengthVec<u8, u8>, Pubkey>,
+}
+
+#[orga]
+impl Chain {
+    pub fn to_btc_script(&self) -> Result<bitcoin::Script> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orga::{
+        encoding::Decode,
+        ibc::{
+            ibc_rs::core::{
+                ics02_client::client_type::ClientType, ics24_host::identifier::ClientId,
+            },
+            Client,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn proof_ok() {
+        let client_type = ibc::clients::ics07_tendermint::client_type();
+        let client_id = ClientId::new(client_type.clone(), 123).unwrap();
+        let height = Height::new(1, 234).unwrap();
+
+        let mut client = Client::default();
+        client.set_client_type(client_type);
+        let cons_state = ibc::clients::ics07_tendermint::consensus_state::ConsensusState::new(
+            CommitmentRoot::from_bytes(
+                hex::decode("A692D537A95AC8B901044896E08767AACF441C0AD42AA08E770954787E108AB3")
+                    .unwrap()
+                    .as_slice(),
+            ),
+            orga::cosmrs::tendermint::Time::now(),
+            Default::default(),
+        );
+        client
+            .consensus_states
+            .insert(height.clone().into(), cons_state.into())
+            .unwrap();
+
+        let mut ibc = Ibc::default();
+        ibc.clients
+            .insert(client_id.clone().into(), client)
+            .unwrap();
+
+        let mut cosmos = Cosmos::default();
+        cosmos
+            .relay_op_key(
+                &ibc,
+                client_id.into(),
+                (1, 234),
+                base64::decode("6Nz09YGHzwWxjczG0IhK4Iv0qY2IcX0P/5KitvRXTUc=").unwrap().try_into().unwrap(),
+                Proof {
+                    inner: Adapter::decode(base64::decode("CooIChYiFMtaY7kej07o25NZQsviVyRjZHngEhTHwgHWY7VtdFjS8dOHOvpv48dXIRoOCAEYASABKgYAAoj3ogIiLggBEgcCBOak/wUgGiEg/L1P7GcEuAt3tWRMFWuAByiQOCRfXnUNvEZHra38kJoiLggBEgcECOak/wUgGiEg3EDxcvi9JC0yAf241+2BROtpz5w/5j72yZ0b4seIXnkiLAgBEigGEL6yoAYg0BUoS2+JjpUm5XfRVqSnImiMe1qcEecJIX48EbmKX20gIi4IARIHCiL8ivMIIBohIJkybuqRRK7SORDUUoky0CMQN3ZZcGRMlBNIWy5Q0i9nIiwIARIoDEq2pcMKIMqzR4D/tncYMpo3qmfmgOlCHycmmyeVbrT6NlgenKxJICIvCAESCA6OAbalwwogGiEgkQCG5HDE7E8+8RNhMBMq8cH0kWmwDrpGOHq1FulPIJgiLQgBEikQjAK2pcMKIPTCfRUi6SVx86EhMwk949typyo8Z+iVHUlr9Rn1D/SbICItCAESKRKoBJCd3AogthJ/IOstJ3Zc2/nWrYg5SY+Qn6dOqBOsJHlArD31jXYgIi0IARIpFIII2oDrCiAsKD2shFKzD9W7p0tTNw/LujIokFa5qnzngHQjh7M28CAiLQgBEikWiAzagOsKIK3xzs2buQxaZb8DcnmDM1OitMSRf+sm+NmzWDiRrRCTICIvCAESCBrWINqA6wogGiEgIk+JGIW+f5vtxYfDYbQv2Ga+K5Ipvl97H9YZ1+puwZ4iLwgBEggeiFPagOsKIBohIJUgd94DqMrR/bi2efHTQRGibmR78e8cZCaJP/RxuOV9IjAIARIJILy7AdqA6wogGiEgeKF9HJJXBOwwnSNfL7MpqCb+JsIUg2KyflFXod6OekciMAgBEgki3PsC2oDrCiAaISAzAk8YSIRO/BuDwcKBEYLubWfOYJ9P6hTovGooMoj9CCIwCAESCSb2+AbagOsKIBohIMX9NlOKH/b3pE4MXvYWNG1f1xrSJpsXd+3kA+8DTLvoIjAIARIJKKygENqA6wogGiEgKNh4fkcXz1b8I39xWpib6pdD2/VWQB335Tu84OsRryEiMAgBEgkqvI0e2oDrCiAaISC1QPv55tP9XUwzqPOY8IY+xlwyZQut2WXeBZ1XhH2BSSIwCAESCSyAjzjagOsKIBohIIzAX+VFI5PHeynHrorJSzZZaT1tIGoxcIdmL0rMsv6gIjAIARIJLqDMX9qA6wogGiEg4gy4OvLAtrVsUuZLRvA33edcEZnUY5hXQDPSc/gCc5UiMQgBEgoy1LnKAfKA6wogGiEgCfupskTR5uwBVIHCP1MmErwkxdpH4aHHtpzPfVyaeAw=").unwrap().as_slice()).unwrap(),
+                    outer: Adapter::decode(base64::decode("CqYCCgdzdGFraW5nEiCUX//ov+S4Hz6HL9602rQ8O0up3EiHV1aUK0+d1Ie/iRoJCAEYASABKgEAIicIARIBARogblpHZ8qVV72aZFAB+TnkB4ZbaVcYQW9rm9tGXp1+6LYiJQgBEiEB2deWtCLjoYYrzc5agnNNqmFPt8nCsoJf7srWHc0OflYiJwgBEgEBGiB3afjCU6KtMVi72g/j0CF5GSQuDKydnca3WYr2qhIbqyIlCAESIQHWUu++vHDx0Ny/FCwlSIh9KlqSHzn5JqCoZNNg1aQHmiIlCAESIQFiHWPnyzFNkFEYmPsI1U1KCIlDjVnysJmHiKttB/OkvSInCAESAQEaIIo6bH1T1ByqB6pctqTyYll7xHtlOBpNvSj9jlPRr/iZ").unwrap().as_slice()).unwrap(),
+                },
+                Proof {
+                    inner: Adapter::decode(base64::decode("Cr8JChUBx8IB1mO1bXRY0vHThzr6b+PHVyESoAEKIC9jb3Ntb3MuYXV0aC52MWJldGExLkJhc2VBY2NvdW50EnwKK29zbW8xY2xwcXI0bnJrNGtoZ2t4ajc4ZmN3d2g2ZGwzdXc0ZXBhc212bmoSRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiECfTKs7KDPbeiIlBmDreAlJuDieStaYcELTb/oCbagOtIY04EBIN4EGg4IARgBIAEqBgACrPjiCiIuCAESBwIErPjiCiAaISC0zYtnKGgp+Fv6/zgK448FNF9nDpE7Wo6+nVNC7eZucyIsCAESKAQGrPjiCiApnLHdr9XrhX0pwIf12puCc+/UcxyISysjLYfyAE+g8yAiLggBEgcGDqz44gogGiEg08ANiRA+u4kL76ki+qtngG3I9Nz6yTeQMa7zp2BO/UgiLAgBEigIFqz44gogQIDbNxIkW40Xj/nOdMOHucM1LelWR//LUYBwaLp5cMEgIi4IARIHCi6s+OIKIBohIBwZipWqbjqW3BRTIuWUrsLvNjCVYU0Iej96K/TLIwLDIi4IARIHDmjy8OoKIBohIP0s1I4EEp3oUMRg6p5+8IU766ZIWQC1fcuZ7M/X3uBUIi8IARIIEMAB8vDqCiAaISCm86iVzVfOI9oodrX7CgbywsDnbySVmfCrybTlTn2iUiIvCAESCBKwAvLw6gogGiEgeUq0y9PKbuZTKsWyQ4H+M7cCZ1gEoDCMFmBzV21dtoEiLwgBEggU1ATy8OoKIBohIOA6LqLAeTdMTJ7alfZ6utZuNJc/vt77kFiFPdbK2GNDIi8IARIIFogK8P/qCiAaISBIw6nPmGUFaeoGOWqRZIXzFvhulSNO9ZyWMHGhesEqpiItCAESKRjWEvD/6gogn9RapcSUmK7mPMniCrDBR9iisvL5xW+KcBxjc7QfxoMgIi0IARIpHMwn8P/qCiCW9uYUBQtWKOXynudhCczCPtV1LUR5zg/hG3fFVarsrSAiLwgBEggewFLw/+oKIBohIAKXW737Ep/LhYonaNPJ6MBzrdF/scK8OFILuyQsTgfcIi4IARIqIOKmAfD/6gognwoyjnbx7OU0hRNpSp+RAXjPXZhWw/JDqyEfg7KmPGQgIi4IARIqIqbJAvD/6gogHl+WnXBgJ6z8ExXQnr1bmTHnC7yGYbeblqBJABF3EesgIi4IARIqJNj1A+6A6woghKduU6A3QoG+nQNZpTgSfsKGovHS8kj5y+yTsGW9mL4gIjAIARIJJpr7B+6A6wogGiEgwssoO2m7jvdHerv3Ah+O/g8IUxUUgSx9mo8Ji5OZ+/8iMAgBEgko3vYP8IDrCiAaISCM6PqvM+y5Q6+WEmiYiRA2WwmEldM93Eru30gXz8Z6dCIwCAESCSqgsBzygOsKIBohIBmf2EZ/NMCXPmKI18qG92WrNAG+oRsNuXVou8uuQgtMIi4IARIqLJTVMfKA6wogTdUhfBcz6GwMd/yPFyDmuVg6mTVk7FHgzYOXwXNBK1AgIi4IARIqLojecfKA6wogIDIgKffpUBAC9R+CNUilqvMl3aNsgCGUx0nA18O1LzYg").unwrap().as_slice()).unwrap(),
+                    outer: Adapter::decode(base64::decode("CqgCCgNhY2MSINEZyJuXGHO9e/7l/BfXyBtNNC1HqaZKWT+WwaRRdm1/GgkIARgBIAEqAQAiJwgBEgEBGiAmJLjLmjFGlQWG6FHRZabBsgRdIizlSVHmg5e8tDXZuyInCAESAQEaILD8zTSz99z8mtIXkoaP1C2nNqMxaadLnIUZqVJl1HhIIicIARIBARoghLjWH7uYlwxi7EtxUYVVeqOV/S7f8LUsmw8AJgdXQHMiJwgBEgEBGiBh6RCHqEWFxCM8X9CEU09AT1ABL3nEmlm+8N0EIRK0JyInCAESAQEaIHaa3mquD4HY2k9dzHkolr9no/ksOfpo92MKSeGX2gFrIicIARIBARogijpsfVPUHKoHqly2pPJiWXvEe2U4Gk29KP2OU9Gv+Jk=").unwrap().as_slice()).unwrap(),
+                },
+            )
+            .unwrap();
+    }
+}

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -47,6 +47,15 @@ pub struct Cosmos {
 
 #[orga]
 impl Cosmos {
+    #[query]
+    pub fn op_key_present(&self, client_id: ClientId, cons_key: LengthVec<u8, u8>) -> Result<bool> {
+        if let Some(chain) = self.chains.get(client_id)? {
+            return Ok(chain.op_keys_by_cons.contains_key(cons_key)?);
+        } else {
+            return Ok(false);
+        }
+    }
+
     pub fn build_outputs(&self, ibc: &Ibc, index: u32) -> Result<Vec<bitcoin::TxOut>> {
         let mut outputs = vec![];
 

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -41,6 +41,7 @@ use orga::{
 };
 use proto::traits::{Message, MessageExt};
 #[cfg(feature = "testnet")]
+#[cfg(feature = "full")]
 use tendermint_rpc::HttpClient;
 
 #[orga]
@@ -371,6 +372,7 @@ impl Chain {
 }
 
 #[cfg(feature = "testnet")]
+#[cfg(feature = "full")]
 pub async fn relay_op_keys<
     W: Wallet,
     F: Fn() -> AppClient<InnerApp, InnerApp, orga::tendermint::client::HttpClient, Nom, W>,

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -1,5 +1,4 @@
 use crate::{
-    app::{InnerApp, Nom},
     bitcoin::{
         signatory::{derive_pubkey, Signatory, SignatorySet},
         threshold_sig::Pubkey,
@@ -7,6 +6,15 @@ use crate::{
     },
     error::Result,
 };
+
+#[cfg(feature = "testnet")]
+use crate::app::{InnerApp, Nom};
+#[cfg(feature = "testnet")]
+use orga::{
+    client::{AppClient, Wallet},
+    macros::build_call,
+};
+
 use bitcoin::{
     secp256k1::Secp256k1,
     util::bip32::{ChildNumber, ExtendedPubKey, Fingerprint},
@@ -21,7 +29,6 @@ use ibc::{
 use ics23::ExistenceProof;
 use orga::{
     abci::prost::Adapter,
-    client::{AppClient, Wallet},
     collections::Map,
     cosmrs::proto,
     encoding::{Decode, Encode, LengthVec},
@@ -30,10 +37,10 @@ use orga::{
         ibc_rs::{core::ics24_host::identifier::PortId, Height},
         Client, ClientId, Ibc,
     },
-    macros::build_call,
     orga, Error as OrgaError,
 };
 use proto::traits::{Message, MessageExt};
+#[cfg(feature = "testnet")]
 use tendermint_rpc::HttpClient;
 
 #[orga]
@@ -363,6 +370,7 @@ impl Chain {
     }
 }
 
+#[cfg(feature = "testnet")]
 pub async fn relay_op_keys<
     W: Wallet,
     F: Fn() -> AppClient<InnerApp, InnerApp, orga::tendermint::client::HttpClient, Nom, W>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use thiserror;
 pub mod airdrop;
 pub mod app;
 pub mod bitcoin;
+pub mod cosmos;
 pub mod error;
 pub mod incentives;
 #[cfg(feature = "full")]


### PR DESCRIPTION
This PR adds emergency disbursal for nBTC on remote chains. In the event of an emergency disbursal, funds can be recovered by the validator set of the chain to which the nBTC was transferred.