### PR TITLE
Adjust Bitcoin fee rate and enable capacity limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,7 @@ required-features = ["csv"]
 [[bin]]
 name = "append-airdrop-snapshot"
 required-features = ["testnet"]
+
+[[test]]
+name = "bitcoin"
+required-features = ["devnet"]

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2342,7 +2342,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "merk"
 version = "2.0.0"
-source = "git+https://github.com/nomic-io/merk?rev=33beb3334e6a55d6f72a55e4bb06af73e8af8904#33beb3334e6a55d6f72a55e4bb06af73e8af8904"
 dependencies = [
  "byteorder",
  "colored",

--- a/src/app.rs
+++ b/src/app.rs
@@ -430,11 +430,6 @@ mod abci {
 
             let sr_address = STRATEGIC_RESERVE_ADDRESS.parse().unwrap();
 
-            self.airdrop
-                .init_from_airdrop1_csv(include_bytes!("../airdrop1_snapshot.csv"))?;
-            self.airdrop
-                .init_from_airdrop2_csv(include_bytes!("../airdrop2_snapshot.csv"))?;
-
             self.accounts.allow_transfers(true);
             self.bitcoin.accounts.allow_transfers(true);
 

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1174,9 +1174,12 @@ impl RelayerCmd {
         let mut relayer = create_relayer().await;
         let checkpoints = relayer.start_checkpoint_relay();
 
+        let mut relayer = create_relayer().await;
+        let checkpoint_confs = relayer.start_checkpoint_conf_relay();
+
         let relaunch = relaunch_on_migrate(&self.config);
 
-        futures::try_join!(headers, deposits, checkpoints, relaunch).unwrap();
+        futures::try_join!(headers, deposits, checkpoints, checkpoint_confs, relaunch).unwrap();
 
         Ok(())
     }

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1436,14 +1436,12 @@ impl CheckpointQueue {
 
 pub fn adjust_fee_rate(prev_fee_rate: u64, up: bool, config: &Config) -> u64 {
     if up {
-        (prev_fee_rate * 5 / 4)
-            .max(prev_fee_rate + 1)
-            .min(config.max_fee_rate)
+        (prev_fee_rate * 5 / 4).max(prev_fee_rate + 1)
     } else {
-        (prev_fee_rate * 3 / 4)
-            .min(prev_fee_rate - 1)
-            .max(config.min_fee_rate)
+        (prev_fee_rate * 3 / 4).min(prev_fee_rate - 1)
     }
+    .min(config.max_fee_rate)
+    .max(config.min_fee_rate)
 }
 
 #[cfg(test)]
@@ -1633,5 +1631,17 @@ mod test {
         let mut queue = create_queue_with_statuses(10, true);
         queue.confirmed_index = None;
         assert_eq!(queue.first_unconfirmed_index().unwrap(), Some(0));
+    }
+
+    #[test]
+    fn adjust_fee_rate() {
+        let config = Config::default();
+        assert_eq!(super::adjust_fee_rate(100, true, &config), 125);
+        assert_eq!(super::adjust_fee_rate(100, false, &config), 75);
+        assert_eq!(super::adjust_fee_rate(2, true, &config), 3);
+        assert_eq!(super::adjust_fee_rate(0, true, &config), 2);
+        assert_eq!(super::adjust_fee_rate(2, false, &config), 2);
+        assert_eq!(super::adjust_fee_rate(200, true, &config), 200);
+        assert_eq!(super::adjust_fee_rate(300, true, &config), 200);
     }
 }

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1458,7 +1458,7 @@ impl CheckpointQueue {
 
 pub fn adjust_fee_rate(prev_fee_rate: u64, up: bool, config: &Config) -> u64 {
     if up {
-        (prev_fee_rate * 5 / 4)
+        (prev_fee_rate * 5 / 4).max(prev_fee_rate + 1)
     } else {
         (prev_fee_rate * 3 / 4).min(prev_fee_rate - 1)
     }
@@ -1673,6 +1673,7 @@ mod test {
 
     #[cfg(feature = "full")]
     #[test]
+    #[serial_test::serial]
     fn fee_adjustments() {
         // TODO: extract pieces into util functions, test more cases
 

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -528,16 +528,29 @@ impl Default for Config {
     }
 }
 
-#[orga(version = 1)]
+#[orga(version = 2)]
 pub struct CheckpointQueue {
     pub queue: Deque<Checkpoint>,
     pub index: u32,
+    #[orga(version(V2))]
+    pub confirmed_index: Option<u32>,
     pub config: Config,
 }
 
 impl MigrateFrom<CheckpointQueueV0> for CheckpointQueueV1 {
     fn migrate_from(_value: CheckpointQueueV0) -> OrgaResult<Self> {
         unreachable!()
+    }
+}
+
+impl MigrateFrom<CheckpointQueueV1> for CheckpointQueueV2 {
+    fn migrate_from(value: CheckpointQueueV1) -> OrgaResult<Self> {
+        Ok(Self {
+            queue: value.queue,
+            index: value.index,
+            confirmed_index: None,
+            config: value.config,
+        })
     }
 }
 

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -132,7 +132,7 @@ impl Config {
             emergency_disbursal_lock_time_interval: 60 * 60 * 24 * 7, //one week
             emergency_disbursal_max_tx_size: 50_000,
             max_offline_checkpoints: 20,
-            min_checkpoint_confirmations: 3,
+            min_checkpoint_confirmations: 2,
         }
     }
 

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -913,6 +913,7 @@ mod tests {
     #[test]
     fn relay_height_validity() {
         Context::add(Paid::default());
+        Context::add(Time::from_seconds(0));
 
         let mut btc = Bitcoin::default();
 

--- a/src/bitcoin/signer.rs
+++ b/src/bitcoin/signer.rs
@@ -182,8 +182,7 @@ where
         }
 
         self.check_change_rates().await?;
-        info!("Signing checkpoint...");
-        dbg!("{} inputs", to_sign.len());
+        info!("Signing checkpoint ({} inputs)...", to_sign.len());
 
         let sigs: LengthVec<u16, Signature> = to_sign
             .into_iter()

--- a/src/bitcoin/signer.rs
+++ b/src/bitcoin/signer.rs
@@ -243,7 +243,7 @@ pub fn sign(
     to_sign: &[([u8; 32], u32)],
 ) -> Result<LengthVec<u16, Signature>> {
     Ok(to_sign
-        .into_iter()
+        .iter()
         .map(|(msg, index)| {
             let privkey = xpriv
                 .derive_priv(secp, &[ChildNumber::from_normal_idx(*index)?])?

--- a/src/bitcoin/signer.rs
+++ b/src/bitcoin/signer.rs
@@ -184,21 +184,7 @@ where
         self.check_change_rates().await?;
         info!("Signing checkpoint ({} inputs)...", to_sign.len());
 
-        let sigs: LengthVec<u16, Signature> = to_sign
-            .into_iter()
-            .map(|(msg, index)| {
-                let privkey = self
-                    .xpriv
-                    .derive_priv(&secp, &[ChildNumber::from_normal_idx(index)?])?
-                    .private_key;
-
-                Ok(secp
-                    .sign_ecdsa(&Message::from_slice(&msg[..])?, &privkey)
-                    .serialize_compact()
-                    .into())
-            })
-            .collect::<Result<Vec<_>>>()?
-            .try_into()?;
+        let sigs = sign(&secp, &self.xpriv, &to_sign)?;
 
         (self.app_client)()
             .call(
@@ -249,4 +235,25 @@ where
 
         Ok(())
     }
+}
+
+pub fn sign(
+    secp: &Secp256k1<bitcoin::secp256k1::SignOnly>,
+    xpriv: &ExtendedPrivKey,
+    to_sign: &[([u8; 32], u32)],
+) -> Result<LengthVec<u16, Signature>> {
+    Ok(to_sign
+        .into_iter()
+        .map(|(msg, index)| {
+            let privkey = xpriv
+                .derive_priv(secp, &[ChildNumber::from_normal_idx(*index)?])?
+                .private_key;
+
+            Ok(secp
+                .sign_ecdsa(&Message::from_slice(&msg[..])?, &privkey)
+                .serialize_compact()
+                .into())
+        })
+        .collect::<Result<Vec<_>>>()?
+        .try_into()?)
 }

--- a/src/bitcoin/signer.rs
+++ b/src/bitcoin/signer.rs
@@ -202,12 +202,7 @@ where
 
         (self.app_client)()
             .call(
-                move |app| {
-                    build_call!(app
-                        .bitcoin
-                        .checkpoints
-                        .sign(xpub.into(), sigs.clone(), index))
-                },
+                move |app| build_call!(app.bitcoin.sign(xpub.into(), sigs.clone(), index)),
                 |app| build_call!(app.app_noop()),
             )
             .await?;

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -573,7 +573,7 @@ async fn bitcoin_test() {
 
             deposit_bitcoin(
                 &funded_accounts[1].address,
-                bitcoin::Amount::from_btc(20).unwrap(),
+                bitcoin::Amount::from_btc(20.0).unwrap(),
                 &wallet,
             )
             .await
@@ -593,7 +593,7 @@ async fn bitcoin_test() {
                 .unwrap();
 
             assert!(broadcast_deposit_addr(
-                &funded_accounts[1].address.to_string(),
+                funded_accounts[1].address.to_string(),
                 deposit_address.sigset_index,
                 "http://localhost:8999".to_string(),
                 deposit_address.deposit_addr.clone(),

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -236,6 +236,9 @@ async fn bitcoin_test() {
     let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind), rpc_addr.clone());
     let disbursal = relayer.start_emergency_disbursal_transaction_relay();
 
+    let mut relayer = Relayer::new(test_bitcoin_client(&bitcoind), rpc_addr.clone());
+    let checkpoint_conf = relayer.start_checkpoint_conf_relay();
+
     let signer = async {
         tokio::time::sleep(Duration::from_secs(20)).await;
         setup_test_signer(&signer_path, client_provider)
@@ -365,6 +368,12 @@ async fn bitcoin_test() {
             .unwrap();
         assert_eq!(balance, Amount::from(0));
 
+        let confirmed_index = app_client()
+            .query(|app| Ok(app.bitcoin.checkpoints.confirmed_index))
+            .await
+            .unwrap();
+        assert_eq!(confirmed_index, None);
+
         poll_for_completed_checkpoint(1).await;
 
         tx.send(Some(())).await.unwrap();
@@ -374,6 +383,23 @@ async fn bitcoin_test() {
             .await
             .unwrap();
         assert_eq!(balance, Amount::from(799998736000000));
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        retry(
+            || bitcoind.client.generate_to_address(3, &wallet_address),
+            10,
+        )
+        .unwrap();
+
+        poll_for_bitcoin_header(1127).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        let confirmed_index = app_client()
+            .query(|app| Ok(app.bitcoin.checkpoints.confirmed_index))
+            .await
+            .unwrap();
+        assert_eq!(confirmed_index, Some(0));
 
         deposit_bitcoin(
             &funded_accounts[1].address,
@@ -389,7 +415,7 @@ async fn bitcoin_test() {
         )
         .unwrap();
 
-        poll_for_bitcoin_header(1128).await.unwrap();
+        poll_for_bitcoin_header(1131).await.unwrap();
         poll_for_completed_checkpoint(2).await;
 
         let balance = app_client()
@@ -413,7 +439,7 @@ async fn bitcoin_test() {
         )
         .unwrap();
 
-        poll_for_bitcoin_header(1132).await.unwrap();
+        poll_for_bitcoin_header(1136).await.unwrap();
         poll_for_completed_checkpoint(3).await;
 
         let signer_jailed = app_client()
@@ -549,6 +575,7 @@ async fn bitcoin_test() {
         deposits,
         checkpoints,
         disbursal,
+        checkpoint_conf,
         signer,
         slashable_signer,
         test


### PR DESCRIPTION
This PR adjusts the Bitcoin fee rate based on whether or not checkpoints were included into Bitcoin blocks, and enables a capacity limit to prevent depositing to certain signatory sets.