### PR TITLE
Stakenet performance fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.4"
+version = "6.0.5"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "merk"
 version = "2.0.0"
-source = "git+https://github.com/nomic-io/merk?rev=34c237624f923c05137e7cb22edf5726482b79ce#34c237624f923c05137e7cb22edf5726482b79ce"
+source = "git+https://github.com/nomic-io/merk?rev=33beb3334e6a55d6f72a55e4bb06af73e8af8904#33beb3334e6a55d6f72a55e4bb06af73e8af8904"
 dependencies = [
  "byteorder",
  "colored",
@@ -2558,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=19af594d964e308e4f207c358be5ea6ce875cab4#19af594d964e308e4f207c358be5ea6ce875cab4"
+source = "git+https://github.com/nomic-io/orga.git?rev=36494fde8a57850c06b8aac65af62ae635efd6a0#36494fde8a57850c06b8aac65af62ae635efd6a0"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=19af594d964e308e4f207c358be5ea6ce875cab4#19af594d964e308e4f207c358be5ea6ce875cab4"
+source = "git+https://github.com/nomic-io/orga.git?rev=36494fde8a57850c06b8aac65af62ae635efd6a0#36494fde8a57850c06b8aac65af62ae635efd6a0"
 dependencies = [
  "darling",
  "heck 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.0.4"
+version = "6.0.5"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nomic"
 [dependencies]
 bitcoin = { version = "0.29.2", features = ["serde", "rand"] }
 bitcoind = { version = "0.27.0", features = ["22_0"], optional = true }
-orga = { git = "https://github.com/nomic-io/orga.git", rev = "19af594d964e308e4f207c358be5ea6ce875cab4", features = ["merk-verify", "compat"] }
+orga = { git = "https://github.com/nomic-io/orga.git", rev = "36494fde8a57850c06b8aac65af62ae635efd6a0", features = ["merk-verify", "compat"] }
 thiserror = "1.0.30"
 ed = { git = "https://github.com/nomic-io/ed", rev = "9c0e206ffdb59dacb90f083e004e8080713e6ad8" }
 clap = { version = "3.2.16", features = ["derive"], optional = true }

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.4"
+version = "6.0.5"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2331,7 +2331,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "merk"
 version = "2.0.0"
-source = "git+https://github.com/nomic-io/merk?rev=34c237624f923c05137e7cb22edf5726482b79ce#34c237624f923c05137e7cb22edf5726482b79ce"
+source = "git+https://github.com/nomic-io/merk?rev=33beb3334e6a55d6f72a55e4bb06af73e8af8904#33beb3334e6a55d6f72a55e4bb06af73e8af8904"
 dependencies = [
  "byteorder",
  "colored",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "orga"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=19af594d964e308e4f207c358be5ea6ce875cab4#19af594d964e308e4f207c358be5ea6ce875cab4"
+source = "git+https://github.com/nomic-io/orga.git?rev=36494fde8a57850c06b8aac65af62ae635efd6a0#36494fde8a57850c06b8aac65af62ae635efd6a0"
 dependencies = [
  "abci2",
  "async-trait",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "orga-macros"
 version = "0.3.1"
-source = "git+https://github.com/nomic-io/orga.git?rev=19af594d964e308e4f207c358be5ea6ce875cab4#19af594d964e308e4f207c358be5ea6ce875cab4"
+source = "git+https://github.com/nomic-io/orga.git?rev=36494fde8a57850c06b8aac65af62ae635efd6a0#36494fde8a57850c06b8aac65af62ae635efd6a0"
 dependencies = [
  "darling",
  "heck 0.3.3",


### PR DESCRIPTION
This PR upgrades to a version of orga with backported performance fixes - namely moving from on-disk checkpoints to in-memory snapshots for recent historical queryable states. This should fix observed issues relating to missed signatures.