### PR TITLE
Circuit breaker improvements

### DIFF
--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1205,13 +1205,13 @@ pub struct SignerCmd {
 
     /// Limits the fraction of the total reserve that may be withdrawn within
     /// the trailing 24-hour period
-    #[clap(long, default_value_t = 0.04)]
+    #[clap(long, default_value_t = 0.1)]
     max_withdrawal_rate: f64,
     /// Limits the maximum allowed signatory set change within 24 hours
     ///
     /// The Total Variation Distance between a day-old signatory set and the
     /// newly-proposed signatory set may not exceed this value
-    #[clap(long, default_value_t = 0.04)]
+    #[clap(long, default_value_t = 0.1)]
     max_sigset_change_rate: f64,
 
     reset_limits_at_index: Option<u32>,

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1213,6 +1213,8 @@ pub struct SignerCmd {
     /// newly-proposed signatory set may not exceed this value
     #[clap(long, default_value_t = 0.04)]
     max_sigset_change_rate: f64,
+
+    reset_limits_at_index: Option<u32>,
 }
 
 impl SignerCmd {
@@ -1229,6 +1231,7 @@ impl SignerCmd {
             key_path,
             self.max_withdrawal_rate,
             self.max_sigset_change_rate,
+            self.reset_limits_at_index,
             // TODO: check for custom RPC port, allow config, etc
             || nomic::app_client("http://localhost:26657").with_wallet(wallet()),
         )?

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1000,6 +1000,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn check_change_rates() -> Result<()> {
         // use checkpoint::*;
         let paid = orga::plugins::Paid::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -194,6 +194,7 @@ where
         key_path,
         0.1,
         1.0,
+        None,
         client,
     )
     .unwrap()

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -272,6 +272,7 @@ async fn bitcoin_test() {
             xpriv,
             0.1,
             1.0,
+            None,
             || {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
@@ -718,6 +719,7 @@ async fn signing_completed_checkpoint_test() {
             xpriv,
             0.1,
             1.0,
+            None,
             || {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
@@ -742,6 +744,7 @@ async fn signing_completed_checkpoint_test() {
             xpriv,
             0.1,
             1.0,
+            None,
             move || {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
@@ -959,6 +962,7 @@ async fn signing_pruned_checkpoint_test() {
             xpriv,
             0.1,
             1.0,
+            None,
             || {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)


### PR DESCRIPTION
This PR adds the `--reset-limits-at-index` flag to `nomic signer`, changes the default signatory set and reserve size decrease limits from 4% to 10%, and improves the way the limits are checked.