### PR TITLE
Timestamping commitments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -495,7 +495,7 @@ mod abci {
             };
             let offline_signers = self
                 .bitcoin
-                .begin_block_step(external_outputs.into_iter().map(Ok))?;
+                .begin_block_step(external_outputs.into_iter().map(Ok), ctx.hash.clone())?;
             for cons_key in offline_signers {
                 let address = self.staking.address_by_consensus_key(cons_key)?.unwrap();
                 self.staking.punish_downtime(address)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ pub struct InnerApp {
 
 #[orga]
 impl InnerApp {
-    pub const CONSENSUS_VERSION: u8 = 6;
+    pub const CONSENSUS_VERSION: u8 = 7;
 
     #[cfg(feature = "full")]
     fn configure_faucets(&mut self) -> Result<()> {

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1767,6 +1767,7 @@ mod test {
                     .into_iter(),
                     btc_height,
                     true,
+                    vec![1, 2, 3],
                 )
                 .unwrap();
         };

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -921,6 +921,7 @@ impl<'a> BuildingCheckpointMut<'a> {
         nbtc_accounts: &Accounts<Nbtc>,
         recovery_scripts: &Map<orga::coins::Address, Adapter<bitcoin::Script>>,
         external_outputs: impl Iterator<Item = Result<bitcoin::TxOut>>,
+        timestamping_commitment: Vec<u8>,
         config: &Config,
     ) -> Result<BuildingAdvanceRes> {
         self.0.status = CheckpointStatus::Signing;
@@ -933,6 +934,11 @@ impl<'a> BuildingCheckpointMut<'a> {
                 .output_script(&[0u8], config.sigset_threshold)?,
         };
 
+        let timestamping_commitment_out = bitcoin::TxOut {
+            value: 0,
+            script_pubkey: bitcoin::Script::new_op_return(&timestamping_commitment),
+        };
+
         let fee_rate = self.fee_rate;
 
         let mut checkpoint_batch = self
@@ -942,6 +948,9 @@ impl<'a> BuildingCheckpointMut<'a> {
             .unwrap();
         let mut checkpoint_tx = checkpoint_batch.get_mut(0)?.unwrap();
 
+        checkpoint_tx
+            .output
+            .push_front(Adapter::new(timestamping_commitment_out))?;
         checkpoint_tx.output.push_front(Adapter::new(reserve_out))?;
 
         let mut excess_inputs = vec![];
@@ -1244,6 +1253,7 @@ impl CheckpointQueue {
         external_outputs: impl Iterator<Item = Result<bitcoin::TxOut>>,
         btc_height: u32,
         should_allow_deposits: bool,
+        timestamping_commitment: Vec<u8>,
     ) -> Result<bool> {
         if !self.should_push(sig_keys)? {
             return Ok(false);
@@ -1266,6 +1276,7 @@ impl CheckpointQueue {
                     nbtc_accounts,
                     recovery_scripts,
                     external_outputs,
+                    timestamping_commitment,
                     &config,
                 )?;
 

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1245,6 +1245,7 @@ impl CheckpointQueue {
     }
 
     #[cfg(feature = "full")]
+    #[allow(clippy::too_many_arguments)]
     pub fn maybe_step(
         &mut self,
         sig_keys: &Map<ConsensusKey, Xpub>,

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1097,7 +1097,8 @@ mod tests {
         let maybe_step = || {
             let mut btc = btc.borrow_mut();
 
-            btc.begin_block_step(vec![].into_iter()).unwrap();
+            btc.begin_block_step(vec![].into_iter(), vec![1, 2, 3])
+                .unwrap();
         };
 
         set_time(0);

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -729,6 +729,7 @@ impl Bitcoin {
     pub fn begin_block_step(
         &mut self,
         external_outputs: impl Iterator<Item = Result<bitcoin::TxOut>>,
+        timestamping_commitment: Vec<u8>,
     ) -> Result<Vec<ConsensusKey>> {
         let has_completed_cp = if let Err(Error::Orga(OrgaError::App(err))) =
             self.checkpoints.last_completed_index()
@@ -757,6 +758,7 @@ impl Bitcoin {
                 external_outputs,
                 self.headers.height()?,
                 !reached_capacity_limit,
+                timestamping_commitment,
             )
             .map_err(|err| OrgaError::App(err.to_string()))?;
 


### PR DESCRIPTION
This PR adds an OP_RETURN output containing a timestamping commitment (committing to the Tendermint block hash of the block where the checkpoint advances to signing) as the second output for every checkpoint transaction. This hash can be used to bootstrap light clients and contains Merkle paths down to the Nomic state, which itself holds block hashes of other chains via their IBC clients.