### PR TITLE
Op key fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.3.0"
+version = "6.3.1"
 authors = ["The Nomic Team <hello@nomic.io>"]
 edition = "2021"
 default-run = "nomic"
@@ -64,7 +64,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 semver = "1.0.18"
 
 [features]
-default = ["full", "feat-ibc", "testnet", "legacy-bin"]
+default = ["full", "feat-ibc", "testnet"]
 full = [
     "bitcoincore-rpc-async",
     "clap",

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -196,8 +196,10 @@ impl Cosmos {
         )?;
 
         let mut chain = self.chains.entry(client_id)?.or_default()?;
-        if chain.op_keys_by_cons.contains_key(cons_key.clone())? {
-            return Err(OrgaError::App("Operator key already relayed".to_string()).into());
+        if let Some(existing_key) = chain.op_keys_by_cons.get(cons_key.clone())? {
+            if *existing_key == op_key {
+                return Err(OrgaError::App("Operator key already relayed".to_string()).into());
+            }
         }
         chain.op_keys_by_cons.insert(cons_key, op_key)?;
 

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -353,7 +353,13 @@ impl Chain {
                 None => continue,
                 Some(op_key) => op_key,
             };
-            let op_key = bitcoin::secp256k1::PublicKey::from_slice(op_key.as_slice())?;
+            let op_key = match bitcoin::secp256k1::PublicKey::from_slice(op_key.as_slice()) {
+                Ok(op_key) => op_key,
+                Err(err) => {
+                    log::debug!("Warning: invalid operator key: {}", err);
+                    continue;
+                }
+            };
 
             let xpub = ExtendedPubKey {
                 network: bitcoin::Network::Bitcoin,


### PR DESCRIPTION
This PR contains an already-released hotfix for a crash relating to invalid remote Cosmos chain operator keys, and a fix for the encoding format and migration for the `Pubkey` type. It also changes the op key relaying method to allow updating keys.