### PR TITLE
Pubkey fix

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ pub struct InnerApp {
 
 #[orga]
 impl InnerApp {
-    pub const CONSENSUS_VERSION: u8 = 7;
+    pub const CONSENSUS_VERSION: u8 = 8;
 
     #[cfg(feature = "full")]
     fn configure_faucets(&mut self) -> Result<()> {

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -1,7 +1,7 @@
 use crate::{
     bitcoin::{
         signatory::{derive_pubkey, Signatory, SignatorySet},
-        threshold_sig::Pubkey,
+        threshold_sig::{Pubkey, VersionedPubkey},
         Nbtc, Xpub,
     },
     error::Result,
@@ -193,7 +193,8 @@ impl Cosmos {
                 .map_err(|_| OrgaError::App("Invalid public key".to_string()))?
                 .key
                 .as_slice(),
-        )?;
+        )?
+        .into();
 
         let mut chain = self.chains.entry(client_id)?.or_default()?;
         if let Some(existing_key) = chain.op_keys_by_cons.get(cons_key.clone())? {
@@ -328,7 +329,7 @@ impl Proof {
 
 #[orga]
 pub struct Chain {
-    pub op_keys_by_cons: Map<LengthVec<u8, u8>, Pubkey>,
+    pub op_keys_by_cons: Map<LengthVec<u8, u8>, VersionedPubkey>,
 }
 
 #[orga]


### PR DESCRIPTION
Properly migrates versionless pubkey encodings, converting pubkeys to all include a version. After all networks have upgraded, this means we can get rid of the `Pubkey`/`VersionedPubkey` distinction.