### PR TITLE
Missing cosmos client fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.4.1"
+version = "6.4.2"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.4.1"
+version = "6.4.2"
 authors = ["The Nomic Team <hello@nomic.io>"]
 edition = "2021"
 default-run = "nomic"
@@ -64,7 +64,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 semver = "1.0.18"
 
 [features]
-default = ["full", "feat-ibc", "testnet", "legacy-bin"]
+default = ["full", "feat-ibc", "testnet"]
 full = [
     "bitcoincore-rpc-async",
     "clap",

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.4.1"
+version = "6.4.2"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -68,14 +68,14 @@ impl Cosmos {
 
         for entry in self.chains.iter()? {
             let (client_id, chain) = entry?;
-            let client = ibc
+            let Some(client) = ibc
                 .ctx
                 .clients
-                .get(client_id.clone())?
-                .ok_or_else(|| OrgaError::Ibc("Client not found".to_string()))?;
-            let sigset = if let Some(sigset) = chain.to_sigset(index, &client)? {
-                sigset
-            } else {
+                .get(client_id.clone())? else {
+                    log::debug!("Warning: client not found");
+                    continue;
+                };
+            let Some(sigset) = chain.to_sigset(index, &client)? else {
                 continue;
             };
 

--- a/src/cosmos.rs
+++ b/src/cosmos.rs
@@ -75,7 +75,13 @@ impl Cosmos {
                     log::debug!("Warning: client not found");
                     continue;
                 };
-            let Some(sigset) = chain.to_sigset(index, &client)? else {
+
+            let sigset_res = chain.to_sigset(index, &client);
+            let Ok(Some(sigset)) = sigset_res else {
+                log::debug!(
+                    "Warning: failed to build sigset ({})",
+                    sigset_res.err().map(|e| e.to_string()).unwrap_or_default(),
+                );
                 continue;
             };
 


### PR DESCRIPTION
Lets the chain continue even when the `cosmos` state is inconsistent from the `ibc` state.