### PR TITLE
Signer Prometheus exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,10 +2388,12 @@ dependencies = [
  "home",
  "ics23",
  "js-sys",
+ "lazy_static",
  "log",
  "mutagen",
  "orga",
  "pretty_env_logger",
+ "prometheus_exporter",
  "rand 0.8.5",
  "reqwest",
  "semver 1.0.18",
@@ -2865,6 +2873,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus_exporter"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf17cbebe0bfdf4f279ef84eeefe0d50468b0b7116f078acf41d456e48fe81a"
+dependencies = [
+ "ascii",
+ "lazy_static",
+ "log",
+ "prometheus",
+ "thiserror",
+ "tiny_http",
 ]
 
 [[package]]
@@ -4125,6 +4161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
  "deranged",
+ "itoa",
  "serde",
  "time-core",
  "time-macros 0.2.11",
@@ -4166,6 +4203,19 @@ dependencies = [
  "quote",
  "standback",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f8734c6d6943ad6df6b588d228a87b4af184998bcffa268ceddf05c2055a8c"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log",
+ "time 0.3.24",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ home = { version = "0.5.5", optional = true }
 semver = "1.0.18"
 ics23 = "0.10.2"
 cosmos-sdk-proto = {version = "0.19.0", optional = true }
+prometheus_exporter = "0.8.5"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 bitcoind = { version = "0.27.0", features = ["22_0"] }

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "clang-sys"
@@ -2315,9 +2327,11 @@ dependencies = [
  "home",
  "ics23",
  "js-sys",
+ "lazy_static",
  "log",
  "orga",
  "pretty_env_logger",
+ "prometheus_exporter",
  "rand 0.8.5",
  "reqwest",
  "semver",
@@ -2866,6 +2880,34 @@ dependencies = [
  "syn 2.0.38",
  "version_check",
  "yansi 1.0.0-rc.1",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus_exporter"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf17cbebe0bfdf4f279ef84eeefe0d50468b0b7116f078acf41d456e48fe81a"
+dependencies = [
+ "ascii",
+ "lazy_static",
+ "log",
+ "prometheus",
+ "thiserror",
+ "tiny_http",
 ]
 
 [[package]]
@@ -4302,6 +4344,19 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tiny_http"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f8734c6d6943ad6df6b588d228a87b4af184998bcffa268ceddf05c2055a8c"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "tinyvec"

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -1217,6 +1217,7 @@ pub struct SignerCmd {
     /// the trailing 24-hour period
     #[clap(long, default_value_t = 0.1)]
     max_withdrawal_rate: f64,
+
     /// Limits the maximum allowed signatory set change within 24 hours
     ///
     /// The Total Variation Distance between a day-old signatory set and the
@@ -1224,6 +1225,10 @@ pub struct SignerCmd {
     #[clap(long, default_value_t = 0.1)]
     max_sigset_change_rate: f64,
 
+    #[clap(long)]
+    prometheus_addr: Option<std::net::SocketAddr>,
+
+    // TODO: should be a flag
     reset_limits_at_index: Option<u32>,
 }
 
@@ -1244,6 +1249,7 @@ impl SignerCmd {
             self.reset_limits_at_index,
             // TODO: check for custom RPC port, allow config, etc
             || nomic::app_client("http://localhost:26657").with_wallet(wallet()),
+            self.prometheus_addr,
         )?
         .start();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -193,6 +193,7 @@ where
         1.0,
         None,
         client,
+        None,
     )
     .unwrap()
 }

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -289,6 +289,7 @@ async fn bitcoin_test() {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
             },
+            None,
         )
         .start();
 
@@ -719,6 +720,7 @@ async fn signing_completed_checkpoint_test() {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
             },
+            None,
         )
         .start();
 
@@ -744,6 +746,7 @@ async fn signing_completed_checkpoint_test() {
                 let wallet = DerivedKey::from_secret_key(privkey);
                 app_client().with_wallet(wallet)
             },
+            None,
         )
         .start()
     };


### PR DESCRIPTION
This PR adds an optional Prometheus exporter to the signer process, allowing for better monitoring of the signer. It can be enabled by passing `--prometheus-addr 127.0.0.1:1234`.