### PR TITLE
Add signatory threshold in relayer /sigset response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.6.0"
+version = "6.6.1"
 authors = ["The Nomic Team <hello@nomic.io>"]
 edition = "2021"
 default-run = "nomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ toml = { version = "0.7.2", features = ["parse"] }
 semver = "1.0.18"
 
 [features]
-default = ["full", "feat-ibc", "testnet", "legacy-bin"]
+default = ["full", "feat-ibc", "testnet"]
 full = [
     "bitcoincore-rpc-async",
     "clap",

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "base64 0.13.1",
  "bech32",

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -949,6 +949,7 @@ pub struct RawSignatorySet {
     pub miner_fee_rate: f64,
     #[serde(rename = "depositsEnabled")]
     pub deposits_enabled: bool,
+    pub threshold: (u64, u64),
 }
 
 impl RawSignatorySet {
@@ -969,6 +970,11 @@ impl RawSignatorySet {
             bridge_fee_rate,
             miner_fee_rate,
             deposits_enabled,
+            // TODO: get threshold from checkpoint once it is stored in state
+            #[cfg(feature = "testnet")]
+            threshold: (9, 10),
+            #[cfg(not(feature = "testnet"))]
+            threshold: (2, 3),
         }
     }
 }


### PR DESCRIPTION
Adds a response field for future-proofing threshold changes when deriving deposit addresses.