### PR TITLE
Stakenet 6 patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.5"
+version = "6.0.6"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomic"
-version = "6.0.5"
+version = "6.0.6"
 authors = [ "The Nomic Team <hello@nomic.io>" ]
 edition = "2021"
 default-run = "nomic"

--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "nomic"
-version = "6.0.5"
+version = "6.0.6"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.9.1",

--- a/src/bin/nomic.rs
+++ b/src/bin/nomic.rs
@@ -104,7 +104,19 @@ impl Command {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         if let Start(cmd) = self {
+            log::info!("nomic v{}", env!("CARGO_PKG_VERSION"));
+
+            if let Some(network) = config.network() {
+                log::info!("Configured for network {:?}", network);
+            }
+
             return Ok(cmd.run()?);
+        }
+
+        log::debug!("nomic v{}", env!("CARGO_PKG_VERSION"));
+
+        if let Some(network) = config.network() {
+            log::debug!("Configured for network {:?}", network);
         }
 
         if let Some(legacy_bin) = legacy_bin(config)? {
@@ -1384,8 +1396,6 @@ pub fn main() {
     .filter_level(log::LevelFilter::Info)
     .parse_env("NOMIC_LOG")
     .init();
-
-    log::debug!("nomic v{}", env!("CARGO_PKG_VERSION"));
 
     let backtrace_enabled = std::env::var("RUST_BACKTRACE").is_ok();
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -42,6 +42,7 @@ impl FromStr for Network {
     fn from_str(s: &str) -> Result<Self> {
         match s.to_lowercase().as_str() {
             "mainnet" => Ok(Self::Mainnet),
+            "stakenet" => Ok(Self::Mainnet),
             "testnet" => Ok(Self::Testnet),
             "local" => Ok(Self::Local),
             _ => Err(Error::Orga(orga::Error::App(format!(

--- a/src/network.rs
+++ b/src/network.rs
@@ -13,6 +13,7 @@ use std::{
 pub enum Network {
     Mainnet,
     Testnet,
+    Local,
 }
 
 impl Network {
@@ -20,6 +21,7 @@ impl Network {
         let toml_src = match self {
             Self::Mainnet => include_str!("../networks/stakenet.toml"),
             Self::Testnet => include_str!("../networks/testnet.toml"),
+            Self::Local => return InnerConfig::default(),
         };
 
         let mut config: InnerConfig = toml::from_str(toml_src).unwrap();
@@ -36,10 +38,12 @@ impl Network {
 
 impl FromStr for Network {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self> {
         match s.to_lowercase().as_str() {
             "mainnet" => Ok(Self::Mainnet),
             "testnet" => Ok(Self::Testnet),
+            "local" => Ok(Self::Local),
             _ => Err(Error::Orga(orga::Error::App(format!(
                 "Invalid network: {s}"
             )))),
@@ -83,8 +87,14 @@ impl Config {
 
     #[cfg(feature = "full")]
     pub fn home_expect(&self) -> Result<PathBuf> {
-        self.home()
-            .ok_or_else(|| orga::Error::App("Cannot get home directory. Please specify either --network, --home, or --chain-id.".to_string()).into())
+        self.home().ok_or_else(|| {
+            // Don't show "--network" in error message if it was specified (e.g. `--network local`)
+            if self.0.network.is_some() {
+                orga::Error::App("Cannot get home directory. Please specify either --home, --chain-id, or --genesis.".to_string())
+            } else {
+                orga::Error::App("Cannot get home directory. Please specify either --network, --home, --chain-id, or --genesis.".to_string())
+            }.into()
+        })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -92,6 +102,17 @@ impl Config {
             && self.0.chain_id.is_none()
             && self.0.genesis.is_none()
             && self.0.home.is_none()
+    }
+
+    pub fn network(&self) -> Option<Network> {
+        match self.0.network {
+            Some(Network::Local) => None,
+            Some(network) => Some(network),
+            #[cfg(feature = "testnet")]
+            None => Some(Network::Testnet),
+            #[cfg(not(feature = "testnet"))]
+            None => Some(Network::Mainnet),
+        }
     }
 }
 
@@ -123,20 +144,7 @@ impl FromArgMatches for Config {
     ) -> std::result::Result<(), clap::Error> {
         self.0.update_from_arg_matches(matches)?;
 
-        if self.is_empty() {
-            self.0.network = match env!("GIT_BRANCH") {
-                "main" => Some(Network::Mainnet),
-                "testnet" => Some(Network::Testnet),
-                _ => None,
-            };
-            if let Some(network) = self.0.network {
-                log::debug!("Using default network: {:?}", network);
-            } else {
-                log::debug!("Built on branch with no default network.");
-            }
-        }
-
-        if let Some(network) = self.0.network {
+        if let Some(network) = self.network() {
             let mut net_config = network.config();
             let arg_config = &self.0;
 


### PR DESCRIPTION
This PR adds patch `6.0.6`, which backports the default network selection and addition of `--network local` which is being introduced in `7.0.0`.