### PR TITLE
Add various endpoints for REST server

### DIFF
--- a/rest/Cargo.lock
+++ b/rest/Cargo.lock
@@ -2363,6 +2363,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint 0.23.7",
+ "tendermint-proto 0.23.9",
  "tendermint-rpc 0.23.7",
  "tokio",
 ]

--- a/rest/Cargo.toml
+++ b/rest/Cargo.toml
@@ -15,6 +15,7 @@ nomic = { path = "..", default-features = false, features = [
 hex = "0.4.3"
 tendermint-rpc = { version = "=0.23.7", features = ["http-client"] }
 tendermint = "=0.23.7"
+tendermint-proto = "=0.23.9"
 base64 = "0.13.0"
 serde = "1.0.136"
 serde_json = "1.0.78"

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use tendermint_rpc as tm;
+use tendermint_proto::types::CommitSig as RawCommitSig;
 use tm::Client as _;
 
 lazy_static::lazy_static! {
@@ -830,7 +831,33 @@ async fn latest_block() -> Value {
         .await
         .unwrap();
 
-    json!(res)
+    let last_commit = res.block.last_commit.unwrap();
+    let signatures: Vec<_> = last_commit.signatures
+        .iter()
+        .map(|signature| -> Value {
+            let signature_raw = RawCommitSig::from(signature.clone());
+
+            json!({
+                "validator_address": base64::encode(signature_raw.validator_address),
+                "block_id_flag": signature_raw.block_id_flag,
+                "timestamp": signature_raw.timestamp,
+                "signature": base64::encode(signature_raw.signature),
+            })
+        })
+        .collect();
+
+    json!({
+        "block_id": res.block_id,
+        "block": {
+            "header": res.block.header,
+            "data": res.block.data,
+            "evidence": res.block.evidence,
+            "last_commit": {
+                "block_id": last_commit.block_id,
+                "signatures": signatures
+            }
+        }
+    })
 }
 
 #[get("/cosmos/base/tendermint/v1beta1/blocks/<height>")]
@@ -842,7 +869,33 @@ async fn block(height: u32) -> Value {
         .await
         .unwrap();
 
-    json!(res)
+    let last_commit = res.block.last_commit.unwrap();
+    let signatures: Vec<_> = last_commit.signatures
+        .iter()
+        .map(|signature| -> Value {
+            let signature_raw = RawCommitSig::from(signature.clone());
+
+            json!({
+                "validator_address": base64::encode(signature_raw.validator_address),
+                "block_id_flag": signature_raw.block_id_flag,
+                "timestamp": signature_raw.timestamp,
+                "signature": base64::encode(signature_raw.signature),
+            })
+        })
+        .collect();
+
+    json!({
+        "block_id": res.block_id,
+        "block": {
+            "header": res.block.header,
+            "data": res.block.data,
+            "evidence": res.block.evidence,
+            "last_commit": {
+                "block_id": last_commit.block_id,
+                "signatures": signatures
+            }
+        }
+    })
 }
 
 #[get("/cosmos/base/tendermint/v1beta1/validatorsets/latest")]

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -24,8 +24,12 @@ lazy_static::lazy_static! {
     static ref QUERY_CACHE: Arc<RwLock<HashMap<String, (u64, String)>>> = Arc::new(RwLock::new(HashMap::new()));
 }
 
+fn app_host() -> &str {
+    "http://localhost:26657"
+}
+
 fn app_client() -> AppClient<InnerApp, InnerApp, HttpClient, Nom, Unsigned> {
-    nomic::app_client("http://localhost:26657")
+    nomic::app_client(app_host())
 }
 
 // DONE /cosmos/bank/v1beta1/balances/{address}
@@ -321,7 +325,7 @@ struct TxRequest {
 async fn txs(tx: &str) -> Result<Value, BadRequest<String>> {
     dbg!(tx);
 
-    let client = tm::HttpClient::new("http://localhost:26657").unwrap();
+    let client = tm::HttpClient::new(app_host()).unwrap();
 
     let tx_bytes = if let Some('{') = tx.chars().next() {
         let tx: TxRequest = serde_json::from_str(tx).unwrap();
@@ -367,7 +371,7 @@ struct TxRequest2 {
 async fn txs2(tx: &str) -> Result<Value, BadRequest<String>> {
     dbg!(tx);
 
-    let client = tm::HttpClient::new("http://localhost:26657").unwrap();
+    let client = tm::HttpClient::new(app_host()).unwrap();
 
     let tx_bytes = if let Some('{') = tx.chars().next() {
         let tx: TxRequest2 = serde_json::from_str(tx).unwrap();
@@ -427,7 +431,7 @@ async fn query(query: &str, height: Option<u32>) -> Result<String, BadRequest<St
     //     }
     // }
 
-    let client = tm::HttpClient::new("http://localhost:26657").unwrap();
+    let client = tm::HttpClient::new(app_host()).unwrap();
 
     let query_bytes = hex::decode(query).map_err(|e| BadRequest(Some(format!("{:?}", e))))?;
 
@@ -819,7 +823,7 @@ async fn slashing_params() -> Value {
 
 #[get("/cosmos/base/tendermint/v1beta1/blocks/latest")]
 async fn latest_block() -> Value {
-    let client = tm::HttpClient::new("http://127.0.0.1:26657").unwrap();
+    let client = tm::HttpClient::new(app_host()).unwrap();
 
     let res = client
         .latest_block()

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -820,7 +820,8 @@ async fn slashing_params() -> Value {
             "slash_fraction_double_sign": slash_fraction_double_sign.to_string(),
             "slash_fraction_downtime": slash_fraction_downtime.to_string()
         }
-    }
+    })
+}
 
 #[get("/cosmos/base/tendermint/v1beta1/blocks/latest")]
 async fn latest_block() -> Value {
@@ -1052,13 +1053,13 @@ fn rocket() -> _ {
             validators,
             validator,
             staking_params,
-            slashing_params
+            slashing_params,
             latest_block,
             block,
             latest_validator_set,
             validator_set,
             community_pool,
             proposals,
-        ],
+        ]
     )
 }

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
     static ref QUERY_CACHE: Arc<RwLock<HashMap<String, (u64, String)>>> = Arc::new(RwLock::new(HashMap::new()));
 }
 
-fn app_host() -> &str {
+fn app_host() -> &'static str {
     "http://localhost:26657"
 }
 
@@ -717,7 +717,7 @@ async fn staking_pool() -> Value {
     let validators = app_client()
         .query(|app| app.staking.all_validators())
         .await
-        .map_err(|e| BadRequest(Some(format!("{:?}", e))))?;
+        .unwrap();
 
     let total_bonded: u64 = validators
         .iter()

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -863,11 +863,11 @@ async fn latest_validator_set() -> Value {
         .map(|validator| -> Value {
             json!({
                 "address": validator.address,
-                "voting_power": validator.power.to_string(),
+                "voting_power": (i64::from(validator.power) / 1_000_000).to_string(),
                 "proposer_priority": i64::from(validator.proposer_priority).to_string(),
                 "pub_key": {
                     "@type": "/cosmos.crypto.ed25519.PubKey",
-                    "value": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
+                    "key": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
                 }
             })
         })
@@ -896,11 +896,11 @@ async fn validator_set(height: u32) -> Value {
         .map(|validator| -> Value {
             json!({
                 "address": validator.address,
-                "voting_power": validator.power.to_string(),
+                "voting_power": (i64::from(validator.power) / 1_000_000).to_string(),
                 "proposer_priority": i64::from(validator.proposer_priority).to_string(),
                 "pub_key": {
                     "@type": "/cosmos.crypto.ed25519.PubKey",
-                    "value": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
+                    "key": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
                 }
             })
         })

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -833,6 +833,18 @@ async fn latest_block() -> Value {
     json!(res)
 }
 
+#[get("/cosmos/base/tendermint/v1beta1/blocks/<height>")]
+async fn block(height: u32) -> Value {
+    let client = tm::HttpClient::new(app_host()).unwrap();
+
+    let res = client
+        .block(tendermint::block::Height::from(height))
+        .await
+        .unwrap();
+
+    json!(res)
+}
+
 #[get("/cosmos/distribution/v1beta1/community_pool")]
 async fn community_pool() -> Value {
     let community_pool = app_client()
@@ -907,6 +919,7 @@ fn rocket() -> _ {
             staking_params,
             slashing_params
             latest_block,
+            block,
             community_pool,
         ],
     )

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -834,9 +834,19 @@ async fn latest_block() -> Value {
 }
 
 #[get("/cosmos/distribution/v1beta1/community_pool")]
-fn community_pool() -> Value {
+async fn community_pool() -> Value {
+    let community_pool = app_client()
+        .query(|app| Ok(app.community_pool.amount))
+        .await
+        .unwrap();
+
     json!({
-        "pool": []
+        "pool": [
+            {
+                "denom": "unom",
+                "amount": community_pool.to_string()
+            }
+        ]
     })
 }
 
@@ -897,6 +907,7 @@ fn rocket() -> _ {
             staking_params,
             slashing_params
             latest_block,
+            community_pool,
         ],
     )
 }

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -916,7 +916,7 @@ async fn latest_validator_set() -> Value {
         .map(|validator| -> Value {
             json!({
                 "address": validator.address,
-                "voting_power": (i64::from(validator.power) / 1_000_000).to_string(),
+                "voting_power": i64::from(validator.power).to_string(),
                 "proposer_priority": i64::from(validator.proposer_priority).to_string(),
                 "pub_key": {
                     "@type": "/cosmos.crypto.ed25519.PubKey",
@@ -949,7 +949,7 @@ async fn validator_set(height: u32) -> Value {
         .map(|validator| -> Value {
             json!({
                 "address": validator.address,
-                "voting_power": (i64::from(validator.power) / 1_000_000).to_string(),
+                "voting_power": i64::from(validator.power).to_string(),
                 "proposer_priority": i64::from(validator.proposer_priority).to_string(),
                 "pub_key": {
                     "@type": "/cosmos.crypto.ed25519.PubKey",

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -859,7 +859,28 @@ async fn latest_validator_set() -> Value {
         .await
         .unwrap();
 
-    json!(res)
+    let validators: Vec<_> = res.validators.iter()
+        .map(|validator| -> Value {
+            json!({
+                "address": validator.address,
+                "voting_power": validator.power.to_string(),
+                "proposer_priority": i64::from(validator.proposer_priority).to_string(),
+                "pub_key": {
+                    "@type": "/cosmos.crypto.ed25519.PubKey",
+                    "value": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
+                }
+            })
+        })
+        .collect();
+
+    json!({
+        "block_height": res.block_height,
+        "validators": validators,
+        "pagination": {
+            "next_key": null,
+            "total": res.validators.len(),
+        }
+    })
 }
 
 #[get("/cosmos/base/tendermint/v1beta1/validatorsets/<height>")]
@@ -871,7 +892,28 @@ async fn validator_set(height: u32) -> Value {
         .await
         .unwrap();
 
-    json!(res)
+        let validators: Vec<_> = res.validators.iter()
+        .map(|validator| -> Value {
+            json!({
+                "address": validator.address,
+                "voting_power": validator.power.to_string(),
+                "proposer_priority": i64::from(validator.proposer_priority).to_string(),
+                "pub_key": {
+                    "@type": "/cosmos.crypto.ed25519.PubKey",
+                    "value": base64::encode(validator.pub_key.ed25519().unwrap().to_bytes()),
+                }
+            })
+        })
+        .collect();
+
+    json!({
+        "block_height": res.block_height,
+        "validators": validators,
+        "pagination": {
+            "next_key": null,
+            "total": res.validators.len(),
+        }
+    })
 }
 
 #[get("/cosmos/distribution/v1beta1/community_pool")]

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -891,6 +891,17 @@ async fn community_pool() -> Value {
     })
 }
 
+#[get("/cosmos/gov/v1beta1/proposals")]
+fn proposals() -> Value {
+    json!({
+        "proposals": [],
+        "pagination": {
+            "next_key": null,
+            "total": 0
+        }
+    })
+}
+
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::Header;
 use rocket::{Request, Response};
@@ -952,6 +963,7 @@ fn rocket() -> _ {
             latest_validator_set,
             validator_set,
             community_pool,
+            proposals,
         ],
     )
 }

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -855,7 +855,7 @@ async fn latest_validator_set() -> Value {
         .unwrap();
 
     let res = client
-        .validators(block.block.header.height, tendermint_rpc::Paging::Default)
+        .validators(block.block.header.height, tendermint_rpc::Paging::All)
         .await
         .unwrap();
 
@@ -867,7 +867,7 @@ async fn validator_set(height: u32) -> Value {
     let client = tm::HttpClient::new(app_host()).unwrap();
 
     let res = client
-        .validators(height, tendermint_rpc::Paging::Default)
+        .validators(height, tendermint_rpc::Paging::All)
         .await
         .unwrap();
 

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -845,6 +845,35 @@ async fn block(height: u32) -> Value {
     json!(res)
 }
 
+#[get("/cosmos/base/tendermint/v1beta1/validatorsets/latest")]
+async fn latest_validator_set() -> Value {
+    let client = tm::HttpClient::new(app_host()).unwrap();
+
+    let block = client
+        .latest_block()
+        .await
+        .unwrap();
+
+    let res = client
+        .validators(block.block.header.height, tendermint_rpc::Paging::Default)
+        .await
+        .unwrap();
+
+    json!(res)
+}
+
+#[get("/cosmos/base/tendermint/v1beta1/validatorsets/<height>")]
+async fn validator_set(height: u32) -> Value {
+    let client = tm::HttpClient::new(app_host()).unwrap();
+
+    let res = client
+        .validators(height, tendermint_rpc::Paging::Default)
+        .await
+        .unwrap();
+
+    json!(res)
+}
+
 #[get("/cosmos/distribution/v1beta1/community_pool")]
 async fn community_pool() -> Value {
     let community_pool = app_client()
@@ -920,6 +949,8 @@ fn rocket() -> _ {
             slashing_params
             latest_block,
             block,
+            latest_validator_set,
+            validator_set,
             community_pool,
         ],
     )

--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -815,6 +815,24 @@ async fn slashing_params() -> Value {
             "slash_fraction_double_sign": slash_fraction_double_sign.to_string(),
             "slash_fraction_downtime": slash_fraction_downtime.to_string()
         }
+    }
+
+#[get("/cosmos/base/tendermint/v1beta1/blocks/latest")]
+async fn latest_block() -> Value {
+    let client = tm::HttpClient::new("http://127.0.0.1:26657").unwrap();
+
+    let res = client
+        .latest_block()
+        .await
+        .unwrap();
+
+    json!(res)
+}
+
+#[get("/cosmos/distribution/v1beta1/community_pool")]
+fn community_pool() -> Value {
+    json!({
+        "pool": []
     })
 }
 
@@ -874,6 +892,7 @@ fn rocket() -> _ {
             validator,
             staking_params,
             slashing_params
+            latest_block,
         ],
     )
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,7 +77,7 @@ pub struct InnerApp {
     #[call]
     pub airdrop: Airdrop,
 
-    community_pool: Coin<Nom>,
+    pub community_pool: Coin<Nom>,
     incentive_pool: Coin<Nom>,
 
     staking_rewards: Faucet<Nom>,


### PR DESCRIPTION
- in validators endpoint, filter validators by status
- updated staking pool endpoint response to be compatible with cosmos-sdk one
- return real values on staking pool endpoint
- added endpoint to return latest/specific block
- added endpoint to return validator set on latest/specific block
- added endpoint to return community pool