### PR TITLE
Bitcoin fee improvements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -179,7 +179,7 @@ impl InnerApp {
 
         let fee = ibc_fee(amount)?;
         let fee = coins.take(fee)?;
-        self.bitcoin.give_fee(fee)?;
+        self.bitcoin.give_rewards(fee)?;
 
         let building = &mut self.bitcoin.checkpoints.building_mut()?;
         let dest = Dest::Ibc(dest);
@@ -994,7 +994,7 @@ impl IbcDest {
 
         let fee_amount = ibc_fee(coins.amount)?;
         let fee = coins.take(fee_amount)?;
-        bitcoin.give_fee(fee)?;
+        bitcoin.give_rewards(fee)?;
         let nbtc_amount = coins.amount;
 
         ibc.transfer_mut()

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,7 +179,7 @@ impl InnerApp {
 
         let fee = ibc_fee(amount)?;
         let fee = coins.take(fee)?;
-        self.bitcoin.reward_pool.give(fee)?;
+        self.bitcoin.give_fee(fee)?;
 
         let building = &mut self.bitcoin.checkpoints.building_mut()?;
         let dest = Dest::Ibc(dest);
@@ -994,7 +994,7 @@ impl IbcDest {
 
         let fee_amount = ibc_fee(coins.amount)?;
         let fee = coins.take(fee_amount)?;
-        bitcoin.reward_pool.give(fee)?;
+        bitcoin.give_fee(fee)?;
         let nbtc_amount = coins.amount;
 
         ibc.transfer_mut()

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -1978,6 +1978,7 @@ impl CheckpointQueue {
         should_allow_deposits: bool,
         timestamping_commitment: Vec<u8>,
         fee_pool: &mut i64,
+        parent_config: &super::Config,
     ) -> Result<bool> {
         if !self.should_push(sig_keys, &timestamping_commitment)? {
             return Ok(false);
@@ -2007,7 +2008,7 @@ impl CheckpointQueue {
                     additional_fees,
                     &config,
                 )?;
-            *fee_pool -= fees_paid as i64;
+            *fee_pool -= (fees_paid * parent_config.units_per_sat) as i64;
 
             // Adjust the fee rate for the next checkpoint based on whether past
             // checkpoints have been confirmed in greater or less than the
@@ -2635,6 +2636,7 @@ mod test {
                     true,
                     vec![1, 2, 3],
                     &mut fee_pool,
+                    &super::super::Config::default(),
                 )
                 .unwrap();
         };
@@ -2849,6 +2851,7 @@ mod test {
                     true,
                     vec![1, 2, 3],
                     &mut fee_pool,
+                    &super::super::Config::default(),
                 )
                 .unwrap();
         };

--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -2454,6 +2454,7 @@ mod test {
                 signed_at_btc_height: None,
                 deposits_enabled: true,
                 sigset: SignatorySet::default(),
+                fees_collected: 0,
             };
             cp.status = status;
             queue.queue.push_back(cp).unwrap();
@@ -2617,7 +2618,8 @@ mod test {
             ..Default::default()
         };
 
-        let maybe_step = |btc_height| {
+        let mut fee_pool = 0;
+        let mut maybe_step = |btc_height| {
             queue
                 .borrow_mut()
                 .maybe_step(
@@ -2632,6 +2634,7 @@ mod test {
                     btc_height,
                     true,
                     vec![1, 2, 3],
+                    &mut fee_pool,
                 )
                 .unwrap();
         };
@@ -2649,6 +2652,7 @@ mod test {
             .unwrap();
             let mut queue = queue.borrow_mut();
             let mut building_mut = queue.building_mut().unwrap();
+            building_mut.fees_collected = 100000000;
             let mut building_checkpoint_batch = building_mut
                 .batches
                 .get_mut(BatchType::Checkpoint as u64)
@@ -2828,7 +2832,8 @@ mod test {
             let time = orga::plugins::Time::from_seconds(time);
             Context::add(time);
         };
-        let maybe_step = |btc_height| {
+        let mut fee_pool = 0;
+        let mut maybe_step = |btc_height| {
             queue
                 .borrow_mut()
                 .maybe_step(
@@ -2843,6 +2848,7 @@ mod test {
                     btc_height,
                     true,
                     vec![1, 2, 3],
+                    &mut fee_pool,
                 )
                 .unwrap();
         };
@@ -2860,6 +2866,7 @@ mod test {
             .unwrap();
             let mut queue = queue.borrow_mut();
             let mut building_mut = queue.building_mut().unwrap();
+            building_mut.fees_collected = 100000000;
             let mut building_checkpoint_batch = building_mut
                 .batches
                 .get_mut(BatchType::Checkpoint as u64)

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1299,9 +1299,13 @@ mod tests {
         };
 
         let secp = Secp256k1::new();
+        #[cfg(feature = "testnet")]
+        let net = bitcoin::Network::Testnet;
+        #[cfg(not(feature = "testnet"))]
+        let net = bitcoin::Network::Bitcoin;
         let xpriv = vec![
-            ExtendedPrivKey::new_master(bitcoin::Network::Testnet, &[0]).unwrap(),
-            ExtendedPrivKey::new_master(bitcoin::Network::Testnet, &[1]).unwrap(),
+            ExtendedPrivKey::new_master(net, &[0]).unwrap(),
+            ExtendedPrivKey::new_master(net, &[1]).unwrap(),
         ];
         let xpub = vec![
             ExtendedPubKey::from_priv(&secp, &xpriv[0]),
@@ -1324,6 +1328,7 @@ mod tests {
             .unwrap();
             let mut btc = btc.borrow_mut();
             let mut building_mut = btc.checkpoints.building_mut().unwrap();
+            building_mut.fees_collected = 100_000_000;
             let mut building_checkpoint_batch = building_mut
                 .batches
                 .get_mut(BatchType::Checkpoint as u64)
@@ -1436,7 +1441,7 @@ mod tests {
         push_withdrawal();
         maybe_step();
         let change_rates = btc.borrow().change_rates(3000, 5100, 0)?;
-        assert_eq!(change_rates.withdrawal, 8652);
+        assert_eq!(change_rates.withdrawal, 8649);
         assert_eq!(change_rates.sigset_change, 4090);
         assert_eq!(btc.borrow().checkpoints.signing()?.unwrap().sigset.index, 5);
         let change_rates = btc.borrow().change_rates(3000, 5100, 5)?;

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1439,7 +1439,7 @@ mod tests {
         push_withdrawal();
         maybe_step();
         let change_rates = btc.borrow().change_rates(3000, 5100, 0)?;
-        assert_eq!(change_rates.withdrawal, 8649);
+        assert_eq!(change_rates.withdrawal, 8651);
         assert_eq!(change_rates.sigset_change, 4090);
         assert_eq!(btc.borrow().checkpoints.signing()?.unwrap().sigset.index, 5);
         let change_rates = btc.borrow().change_rates(3000, 5100, 5)?;

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -511,7 +511,9 @@ impl Bitcoin {
     /// checkpoint to `Signing`). Returns `false` otherwise.
     #[cfg(feature = "full")]
     pub fn should_push_checkpoint(&mut self) -> Result<bool> {
-        self.checkpoints.should_push(self.signatory_keys.map())
+        self.checkpoints
+            .should_push(self.signatory_keys.map(), &[0; 32])
+        // TODO: we shouldn't need this slice, commitment should be fixed-length
     }
 
     /// Verifies and processes a deposit of BTC into the reserve.

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -613,10 +613,8 @@ impl Bitcoin {
         let fee_amount = input_size * checkpoint.fee_rate * self.checkpoints.config.user_fee_factor
             / 10_000
             * self.config.units_per_sat;
-        let fee = nbtc.take(fee_amount).or_else(|_| {
-            Err(OrgaError::App(
-                "Deposit amount is too small to pay its spending fee".to_string(),
-            ))
+        let fee = nbtc.take(fee_amount).map_err(|_| {
+            OrgaError::App("Deposit amount is too small to pay its spending fee".to_string())
         })?;
         self.give_miner_fee(fee)?;
         // TODO: record as excess collected if inputs are full
@@ -644,7 +642,7 @@ impl Bitcoin {
         checkpoint_tx.input.push_back(input)?;
         // TODO: keep in excess queue if full
 
-        let deposit_fee = nbtc.take(calc_deposit_fee(nbtc.amount.clone().into()))?;
+        let deposit_fee = nbtc.take(calc_deposit_fee(nbtc.amount.into()))?;
         self.give_rewards(deposit_fee)?;
 
         self.checkpoints
@@ -755,10 +753,8 @@ impl Bitcoin {
             * self.checkpoints.config.user_fee_factor
             / 10_000
             * self.config.units_per_sat;
-        let fee = coins.take(fee_amount).or_else(|_| {
-            Err(OrgaError::App(
-                "Withdrawal is too small to pay its miner fee".to_string(),
-            ))
+        let fee = coins.take(fee_amount).map_err(|_| {
+            OrgaError::App("Withdrawal is too small to pay its miner fee".to_string())
         })?;
         self.give_miner_fee(fee)?;
         // TODO: record as collected for excess if full

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -962,6 +962,7 @@ impl Bitcoin {
                 !reached_capacity_limit,
                 timestamping_commitment,
                 &mut self.fee_pool,
+                &self.config,
             )
             .map_err(|err| OrgaError::App(err.to_string()))?;
 
@@ -1063,7 +1064,8 @@ impl Bitcoin {
     }
 
     pub fn give_rewards(&mut self, coin: Coin<Nbtc>) -> Result<()> {
-        if self.fee_pool < self.config.fee_pool_target_balance as i64 {
+        if self.fee_pool < (self.config.fee_pool_target_balance * self.config.units_per_sat) as i64
+        {
             let amount: u64 = coin.amount.into();
             coin.burn();
 

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -607,7 +607,8 @@ impl Bitcoin {
         )?;
         let input_size = input.est_vsize();
 
-        let fee = input_size * checkpoint.fee_rate;
+        let fee =
+            input_size * checkpoint.fee_rate * self.checkpoints.config.user_fee_factor / 10_000;
         let value = output.value.checked_sub(fee).ok_or_else(|| {
             OrgaError::App("Deposit amount is too small to pay its spending fee".to_string())
         })? * self.config.units_per_sat;
@@ -737,7 +738,10 @@ impl Bitcoin {
             .into());
         }
 
-        let fee = (9 + script_pubkey.len() as u64) * self.checkpoints.building()?.fee_rate;
+        let fee = (9 + script_pubkey.len() as u64)
+            * self.checkpoints.building()?.fee_rate
+            * self.checkpoints.config.user_fee_factor
+            / 10_000;
         let value: u64 = Into::<u64>::into(amount) / self.config.units_per_sat;
         let value = match value.checked_sub(fee) {
             None => {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -610,8 +610,9 @@ impl Bitcoin {
         let input_size = input.est_vsize();
 
         let mut nbtc = Nbtc::mint(output.value * self.config.units_per_sat);
-        let fee_amount =
-            input_size * checkpoint.fee_rate * self.checkpoints.config.user_fee_factor / 10_000;
+        let fee_amount = input_size * checkpoint.fee_rate * self.checkpoints.config.user_fee_factor
+            / 10_000
+            * self.config.units_per_sat;
         let fee = nbtc.take(fee_amount).or_else(|_| {
             Err(OrgaError::App(
                 "Deposit amount is too small to pay its spending fee".to_string(),

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1332,7 +1332,7 @@ mod tests {
         push_withdrawal();
         maybe_step();
         let change_rates = btc.borrow().change_rates(3000, 5100, 0)?;
-        assert_eq!(change_rates.withdrawal, 8649);
+        assert_eq!(change_rates.withdrawal, 8652);
         assert_eq!(change_rates.sigset_change, 4090);
         assert_eq!(btc.borrow().checkpoints.signing()?.unwrap().sigset.index, 5);
         let change_rates = btc.borrow().change_rates(3000, 5100, 5)?;

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1061,6 +1061,16 @@ impl Bitcoin {
 
         Ok(())
     }
+
+    #[call]
+    pub fn give_to_fee_pool(&mut self, amount: Amount) -> Result<()> {
+        let taken_coins = self
+            .context::<Paid>()
+            .ok_or_else(|| orga::Error::Coins("No Paid context found".into()))?
+            .take(amount)?;
+
+        self.give_fee(taken_coins)
+    }
 }
 
 /// The current rates of change of the reserve output and signatory set, in

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -519,7 +519,7 @@ async fn bitcoin_test() {
                 }
             }
         }
-        assert_eq!(signatory_balance, 49991191);
+        assert_eq!(signatory_balance, 49986239);
 
         let funded_account_balances: Vec<_> = funded_accounts
             .iter()

--- a/tests/bitcoin.rs
+++ b/tests/bitcoin.rs
@@ -410,7 +410,7 @@ async fn bitcoin_test() {
             .query(|app| app.bitcoin.accounts.balance(funded_accounts[0].address))
             .await
             .unwrap();
-        assert_eq!(balance, Amount::from(989998435800000));
+        assert_eq!(balance, Amount::from(989996871600000));
 
         btc_client
             .generate_to_address(3, &async_wallet_address)
@@ -440,7 +440,7 @@ async fn bitcoin_test() {
             .await
             .unwrap();
 
-        assert_eq!(balance, Amount::from(39597653700000));
+        assert_eq!(balance, Amount::from(39595307400000));
 
         withdraw_bitcoin(
             &funded_accounts[0],
@@ -474,7 +474,7 @@ async fn bitcoin_test() {
             .query(|app| app.bitcoin.accounts.balance(funded_accounts[0].address))
             .await
             .unwrap();
-        assert_eq!(balance, Amount::from(989991435800000));
+        assert_eq!(balance, Amount::from(989989871600000));
 
         let disbursal_txs = app_client()
             .query(|app: InnerApp| {
@@ -519,7 +519,7 @@ async fn bitcoin_test() {
                 }
             }
         }
-        assert_eq!(signatory_balance, 49989255);
+        assert_eq!(signatory_balance, 49991191);
 
         let funded_account_balances: Vec<_> = funded_accounts
             .iter()
@@ -534,7 +534,7 @@ async fn bitcoin_test() {
             })
             .collect();
 
-        let expected_account_balances: Vec<u64> = vec![989989593, 0, 0, 0];
+        let expected_account_balances: Vec<u64> = vec![989988029, 0, 0, 0];
         assert_eq!(funded_account_balances, expected_account_balances);
 
         for (i, account) in funded_accounts[0..1].iter().enumerate() {


### PR DESCRIPTION
This PR improves the algorithms related to paying Bitcoin miner fees in bridge checkpoint transactions.

## Motivation
The Bitcoin network has recently seen unprecedented levels of onchain activity, leading to an unpredictable fee market with spikes of high fee rates in order for transactions to be mined. This affects Nomic since the network periodically produces transactions and must include a fee.

The bridge adjusts fee rates up or down based on whether it sees timely inclusion in a Bitcoin block, assigning an updated fee rate to each new checkpoint. However, user deposit addresses are tied to the fee rate quoted in the UI when depositing rather than the current best fee rate (for UX purposes). This leads to checkpoints' effective fee rate often being too low, leaving the checkpoints stuck in the mempool.

Additionally, Nomic has a limit on how many checkpoints can be unconfirmed before halting checkpoint production (currently configured to 15 on stakenet), so these stuck checkpoints lead to all nBTC transfers being halted. Since the network only applies the adjusted fee rate to the newest checkpoint, it would often require more than 15 adjustments before the entire unconfirmed bundle of checkpoints are at a rate which will be mined.

## Solution
To keep checkpoints' effective fee at the most recent adjusted rate, the network now calculates the amount of additional fees required to put the entire unconfirmed bundle of checkpoint transactions at the new rate. This will result in needing far fewer checkpoints to adjust the bundle to any fee rate the Bitcoin network might require, preventing the bundle from hitting the limit of 15 unconfirmed.

However, this now creates an economic problem since the network is effectively paying for much of the miner fees for users' deposits, which would be unsustainable since the nBTC must be sourced from somewhere. This is addressed by the creation of a network-owned **fee pool**, where nBTC may be drawn from to pay the network's miner fees and adjust any deposits which paid too low of a fee rate. The fee pool is funded by multiplying the current fee rate by a parameter (the **user fee factor**) when deducting fees from user deposits in an attempt to contribute a positive balance to the fee pool for most deposits. In this PR the parameter will be set to 2, but this can be controlled by network governance in the future.

To help the network build a surplus in the fee pool, checkpoints will not be produced if the amount of fees to be paid is higher than the amount collected (where the amount collected is the amount of fees charged for the deposits and withdrawals in that checkpoint) - unless the maximum checkpoint interval has passed. Users can also contribute nBTC directly into the fee pool if there is a negative balance and they want to speed up progress. Additionally, the network will redirect protocol revenue (e.g. bridge fees and IBC transfer fees, as opposed to miner fees) to the fee pool when it is below a target balance parameter.

## Technical Notes
- The fee pool is implemented as a `i64` where it should be a `Coin<Nbtc>`, because it is theoretically possible (although unlikely) to have a negative balance. In the future, hard guarantees that the balance cannot go negative can be added and this can be converted to a `Coin`.
- The fee pool is the single authoritative balance which can be added to and drawn from - the `fees_collected` field in `Checkpoint` shouldn't be thought of as an account or pool, but just as a counted quantity that was contributed to the fee pool.
- Since the count of collected fees is per-checkpoint, checkpoints with excess inputs and outputs will overcount the collected fees, and the later checkpoints where the excess checkpoints will actually be included will be undercounted. This is OK but can lead to holding back the later checkpoints when it isn't necessary - this can be addressed in a future change by counting the collected fees per-input and per-output.

## Future Work
Instead of setting a network-wide "user fee factor", users or applications could be allowed to pick any fee rate they want (at deposit address generation time). Then, the network could choose to process the higher-paying deposits first, letting a fee market develop during times of bridge congestion, and allowing for more advanced policies in choosing which deposits to process.