### PR TITLE
Ensure resulting threshold integer matches script in `SignatorySet::from_script`

### DIFF
--- a/src/bitcoin/checkpoint.rs
+++ b/src/bitcoin/checkpoint.rs
@@ -2372,6 +2372,7 @@ impl CheckpointQueue {
         &mut self,
         first_index: u32,
         redeem_scripts: impl Iterator<Item = Script>,
+        threshold_ratio: (u64, u64),
     ) -> Result<()> {
         let mut index = first_index + 1;
 
@@ -2384,7 +2385,7 @@ impl CheckpointQueue {
                 continue;
             }
 
-            let (mut sigset, _) = SignatorySet::from_script(&script)?;
+            let (mut sigset, _) = SignatorySet::from_script(&script, threshold_ratio)?;
             sigset.index = index;
             sigset.create_time = create_time;
             let mut cp = Checkpoint::new(sigset)?;
@@ -3035,7 +3036,9 @@ mod test {
             sigset(4).redeem_script(&[0], (2, 3)).unwrap(),
             sigset(3).redeem_script(&[0], (2, 3)).unwrap(),
         ];
-        queue.backfill(8, backfill_data.into_iter()).unwrap();
+        queue
+            .backfill(8, backfill_data.into_iter(), (2, 3))
+            .unwrap();
 
         assert_eq!(queue.len().unwrap(), 8);
         assert_eq!(queue.index, 10);
@@ -3069,7 +3072,9 @@ mod test {
             .unwrap();
 
         let backfill_data = vec![sigset(0).redeem_script(&[0], (2, 3)).unwrap()];
-        queue.backfill(0, backfill_data.into_iter()).unwrap();
+        queue
+            .backfill(0, backfill_data.into_iter(), (2, 3))
+            .unwrap();
 
         assert_eq!(queue.len().unwrap(), 2);
         assert_eq!(queue.index, 1);

--- a/src/bitcoin/signatory.rs
+++ b/src/bitcoin/signatory.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::redundant_closure_call)] // TODO: fix bitcoin-script then remove this
 #![allow(unused_imports)] // TODO
 
+use std::cmp::Ordering;
+
 use crate::bitcoin::threshold_sig::Pubkey;
 use crate::error::Error;
 use crate::error::Result;
@@ -300,14 +302,16 @@ impl SignatorySet {
 
         for _ in 0..100 {
             let actual_threshold = sigset.signature_threshold(threshold_ratio);
-            if actual_threshold == expected_threshold {
-                break;
-            } else if actual_threshold < expected_threshold {
-                sigset.present_vp += 1;
-                sigset.possible_vp += 1;
-            } else {
-                sigset.present_vp -= 1;
-                sigset.possible_vp -= 1;
+            match actual_threshold.cmp(&expected_threshold) {
+                Ordering::Equal => break,
+                Ordering::Less => {
+                    sigset.present_vp += 1;
+                    sigset.possible_vp += 1;
+                }
+                Ordering::Greater => {
+                    sigset.present_vp -= 1;
+                    sigset.possible_vp -= 1;
+                }
             }
         }
 


### PR DESCRIPTION
When deriving a `SignatorySet` from a redeem script, the resulting threshold value may be calculated differently when derived from truncated voting power vs non-truncated voting power. To ensure the threshold is the same regardless, this PR compares to the expected threshold in the redeem script passed in, and adjusts the `present_vp` field accordingly.