### PR TITLE
Pending deposit detail

### DIFF
--- a/src/bitcoin/deposit_index.rs
+++ b/src/bitcoin/deposit_index.rs
@@ -5,21 +5,12 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Deposit {
-    txid: Txid,
-    vout: u32,
-    amount: u64,
-    height: Option<u64>,
-}
-
-impl Deposit {
-    pub fn new(txid: Txid, vout: u32, amount: u64, height: Option<u64>) -> Self {
-        Self {
-            txid,
-            vout,
-            amount,
-            height,
-        }
-    }
+    pub txid: Txid,
+    pub vout: u32,
+    pub amount: u64,
+    pub height: Option<u64>,
+    pub sigset_index: u32,
+    pub miner_fee_rate: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/bitcoin/deposit_index.rs
+++ b/src/bitcoin/deposit_index.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Deposit {
     pub txid: Txid,
     pub vout: u32,

--- a/src/bitcoin/deposit_index.rs
+++ b/src/bitcoin/deposit_index.rs
@@ -11,6 +11,7 @@ pub struct Deposit {
     pub height: Option<u64>,
     pub sigset_index: u32,
     pub miner_fee_rate: f64,
+    pub bridge_fee_rate: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -2,6 +2,7 @@ use super::signatory::Signatory;
 use super::SignatorySet;
 use super::SIGSET_THRESHOLD;
 use crate::app::Dest;
+use crate::app::InnerApp;
 use crate::app_client;
 use crate::bitcoin::deposit_index::{Deposit, DepositIndex};
 use crate::bitcoin::{adapter::Adapter, header_queue::WrappedHeader};
@@ -273,6 +274,8 @@ impl Relayer {
                 let sigset = app_client(app_client_addr)
                     .query(|app: crate::app::InnerApp| {
                         let building = app.bitcoin.checkpoints.building()?;
+                        // TODO: use self.miner_fee_rate() once this endpoint
+                        // takes an optional `index` arg.
                         let est_miner_fee =
                             (app.bitcoin.checkpoints.active_sigset()?.est_witness_vsize() + 40)
                                 * building.fee_rate
@@ -440,7 +443,9 @@ impl Relayer {
                     return Ok(());
                 }
 
-                if let Some((dest, _)) = script_guard.as_ref().unwrap().scripts.get(&script) {
+                if let Some((dest, sigset_index)) =
+                    script_guard.as_ref().unwrap().scripts.get(&script)
+                {
                     let bitcoin_address = bitcoin::Address::from_script(
                         &output.script_pubkey.clone(),
                         super::NETWORK,
@@ -451,10 +456,20 @@ impl Relayer {
                         Some(addr) => addr,
                         None => continue,
                     };
+
+                    let miner_fee_rate = self.miner_fee_rate(sigset_index).await?;
+
                     index.insert_deposit(
                         receiver_addr,
                         bitcoin_address,
-                        Deposit::new(txid, vout as u32, output.value, None),
+                        Deposit {
+                            txid,
+                            vout: vout as u32,
+                            amount: output.value,
+                            height: None,
+                            sigset_index,
+                            miner_fee_rate,
+                        },
                     )
                 }
             }
@@ -462,6 +477,23 @@ impl Relayer {
         }
 
         Ok(())
+    }
+
+    pub async fn miner_fee_rate(&self, sigset_index: u32) -> Result<f64> {
+        let client = app_client(&self.app_client_addr);
+        let miner_fee_rate = client
+            .query(|app: InnerApp| {
+                let chkpt = app.bitcoin.checkpoints.get(sigset_index)?;
+                let est_miner_fee = (chkpt.sigset.est_witness_vsize() + 40)
+                    * chkpt.fee_rate
+                    * app.bitcoin.checkpoints.config.user_fee_factor
+                    / 10_000;
+
+                Ok(est_miner_fee as f64 / 100_000_000.0)
+            })
+            .await?;
+
+        Ok(miner_fee_rate)
     }
 
     pub async fn start_emergency_disbursal_transaction_relay(&mut self) -> Result<()> {
@@ -885,6 +917,7 @@ impl Relayer {
         let outpoint = (txid.into_inner(), output.vout);
         let dest = output.dest.clone();
         let vout = output.vout;
+        let sigset_index = output.sigset_index;
         let contains_outpoint = app_client(&self.app_client_addr)
             .query(|app| app.bitcoin.processed_outpoints.contains(outpoint))
             .await?;
@@ -901,16 +934,20 @@ impl Relayer {
                 return Ok(());
             }
 
+            let miner_fee_rate = self.miner_fee_rate(sigset_index).await?;
+
             let mut index_guard = index.lock().await;
             index_guard.insert_deposit(
                 receiver_addr,
                 deposit_address.clone(),
-                Deposit::new(
+                Deposit {
                     txid,
                     vout,
-                    tx.output.get(vout as usize).unwrap().value,
-                    Some(height.into()),
-                ),
+                    amount: tx.output.get(vout as usize).unwrap().value,
+                    height: Some(height.into()),
+                    sigset_index,
+                    miner_fee_rate,
+                },
             );
         }
 


### PR DESCRIPTION
This PR adds sigset index, miner fee, and bridge fee info to the response from the BTC relayer's `/pending_deposits` endpoint.