### PR TITLE
Destination-specific bridge fee rate quotes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -89,7 +89,7 @@ const IBC_FEE_USATS: u64 = 1_000_000;
 /// The fixed amount of nBTC fee required to make any application call, in
 /// micro-satoshis.
 const CALL_FEE_USATS: u64 = 100_000_000;
-const OSMOSIS_CHANNEL_ID: &str = "channel-1";
+pub const OSMOSIS_CHANNEL_ID: &str = "channel-1";
 
 /// The top-level application state type and logic. This contains the major
 /// state types for the various subsystems of the Nomic protocol.

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -1099,14 +1099,12 @@ impl Default for BridgeFeeOverrides {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RawSignatorySet {
     pub signatories: Vec<RawSignatory>,
     pub index: u32,
-    #[serde(rename = "bridgeFeeRate")]
     pub bridge_fee_rate: f64,
-    #[serde(rename = "minerFeeRate")]
     pub miner_fee_rate: f64,
-    #[serde(rename = "depositsEnabled")]
     pub deposits_enabled: bool,
     pub threshold: (u64, u64),
     pub bridge_fee_overrides: BridgeFeeOverrides,

--- a/src/bitcoin/relayer.rs
+++ b/src/bitcoin/relayer.rs
@@ -1084,6 +1084,19 @@ pub struct OutputMatch {
     vout: u32,
     dest: Dest,
 }
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct BridgeFeeOverrides {
+    /// Map of channel id to bridge fee rate
+    pub ibc: HashMap<String, f64>,
+}
+
+impl Default for BridgeFeeOverrides {
+    fn default() -> Self {
+        Self {
+            ibc: HashMap::from([(crate::app::OSMOSIS_CHANNEL_ID.to_string(), 0.0)]),
+        }
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct RawSignatorySet {
@@ -1096,6 +1109,7 @@ pub struct RawSignatorySet {
     #[serde(rename = "depositsEnabled")]
     pub deposits_enabled: bool,
     pub threshold: (u64, u64),
+    pub bridge_fee_overrides: BridgeFeeOverrides,
 }
 
 impl RawSignatorySet {
@@ -1121,6 +1135,7 @@ impl RawSignatorySet {
             threshold: (9, 10),
             #[cfg(not(feature = "testnet"))]
             threshold: (2, 3),
+            bridge_fee_overrides: BridgeFeeOverrides::default(),
         }
     }
 }


### PR DESCRIPTION
This PR adds `bridge_fee_overrides` to the response from the BTC relayer's `/sigset` endpoint, allowing dest-specific bridge fee rate quotes for clients.