### PR TITLE
Add custom 404 for REST

### DIFF
--- a/rest/src/main.rs
+++ b/rest/src/main.rs
@@ -1454,9 +1454,19 @@ impl Fairing for CORS {
     }
 }
 
+
+#[catch(404)]
+fn not_found(req: &Request) -> Value {
+    json!({
+        "code": 12,
+        "message": "Not Implemented",
+        "details": []
+    })
+}
+
 #[launch]
 fn rocket() -> _ {
-    rocket::build().attach(CORS).mount(
+    rocket::build().attach(CORS).register("/", catchers![not_found]).mount(
         "/",
         routes![
             bank_balances,


### PR DESCRIPTION
Rocket's default 404 handler makes it extremely unobvious there's a LCD-like interface behind this API it exposes, so I did a custom 404 handler that responds the same way cosmos-sdk LCD responds when the query is not found.